### PR TITLE
Add placeholder tests and fuzz targets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,6 +59,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+
+[[package]]
 name = "assert_cmd"
 version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -105,6 +111,17 @@ name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "cc"
+version = "1.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42bc4aea80032b7bf409b0bc7ccad88853858911b7713a8062fdc0623867bedc"
+dependencies = [
+ "jobserver",
+ "libc",
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
@@ -161,10 +178,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
+name = "cli"
+version = "0.1.0"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "compress"
+version = "0.1.0"
 
 [[package]]
 name = "crypto-common"
@@ -199,6 +224,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
+name = "engine"
+version = "0.1.0"
+
+[[package]]
 name = "errno"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -213,6 +242,19 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "filters"
+version = "0.1.0"
+
+[[package]]
+name = "fuzz"
+version = "0.1.0"
+dependencies = [
+ "filters",
+ "libfuzzer-sys",
+ "protocol",
+]
 
 [[package]]
 name = "generic-array"
@@ -255,10 +297,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom",
+ "libc",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
+
+[[package]]
+name = "libfuzzer-sys"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5037190e1f70cbeef565bd267599242926f724d3b8a9f510fd7e0b540cfa4404"
+dependencies = [
+ "arbitrary",
+ "cc",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -281,6 +343,10 @@ name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+
+[[package]]
+name = "meta"
+version = "0.1.0"
 
 [[package]]
 name = "once_cell"
@@ -405,6 +471,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -441,6 +513,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
+name = "transport"
+version = "0.1.0"
+
+[[package]]
 name = "typenum"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -472,6 +548,10 @@ checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "walk"
+version = "0.1.0"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,10 +10,8 @@ members = [
     "crates/transport",
     "crates/cli",
     "crates/fuzz",
-    "bin/rsync-rs",
 ]
 resolver = "2"
-members = ["crates/protocol", "crates/checksums"]
 
 [package]
 name = "rsync-rs"

--- a/README.md
+++ b/README.md
@@ -35,3 +35,20 @@ rsync-rs aims to provide a Rust reimplementation of the classic `rsync` utility.
 3. **Networking** – add remote transport over SSH and TCP.
 4. **CLI Parity** – mirror key rsync flags and behaviors.
 5. **Stabilization** – cross-platform polish and documentation.
+
+## Testing
+Run the full test suite with:
+
+```
+cargo test
+```
+
+## Fuzzing
+The project includes fuzz targets under `crates/fuzz`. To run them, install [`cargo-fuzz`](https://github.com/rust-fuzz/cargo-fuzz) and execute:
+
+```
+cargo install cargo-fuzz
+cd crates/fuzz
+cargo fuzz run protocol_frame_decode_fuzz
+cargo fuzz run filters_parse_fuzz
+```

--- a/crates/checksums/src/lib.rs
+++ b/crates/checksums/src/lib.rs
@@ -74,3 +74,4 @@ mod tests {
         assert_eq!(hex::encode(digest), "5eb63bbbe01eeed093cb22bb8f5acdc3");
     }
 }
+}

--- a/crates/checksums/tests/placeholder.rs
+++ b/crates/checksums/tests/placeholder.rs
@@ -1,0 +1,4 @@
+#[test]
+fn placeholder() {
+    assert_eq!(2 + 2, 4);
+}

--- a/crates/cli/tests/placeholder.rs
+++ b/crates/cli/tests/placeholder.rs
@@ -1,0 +1,4 @@
+#[test]
+fn placeholder() {
+    assert_eq!(2 + 2, 4);
+}

--- a/crates/compress/tests/placeholder.rs
+++ b/crates/compress/tests/placeholder.rs
@@ -1,0 +1,4 @@
+#[test]
+fn placeholder() {
+    assert_eq!(2 + 2, 4);
+}

--- a/crates/engine/tests/placeholder.rs
+++ b/crates/engine/tests/placeholder.rs
@@ -1,0 +1,4 @@
+#[test]
+fn placeholder() {
+    assert_eq!(2 + 2, 4);
+}

--- a/crates/filters/src/lib.rs
+++ b/crates/filters/src/lib.rs
@@ -1,3 +1,9 @@
 pub mod filters {
     // Placeholder for the filters crate.
+
+    /// Parse filter rules from input.
+    pub fn parse(_input: &str) -> Result<(), &'static str> {
+        // Placeholder parser implementation
+        Ok(())
+    }
 }

--- a/crates/filters/tests/placeholder.rs
+++ b/crates/filters/tests/placeholder.rs
@@ -1,0 +1,4 @@
+#[test]
+fn placeholder() {
+    assert_eq!(2 + 2, 4);
+}

--- a/crates/fuzz/Cargo.toml
+++ b/crates/fuzz/Cargo.toml
@@ -2,3 +2,24 @@
 name = "fuzz"
 version = "0.1.0"
 edition = "2021"
+publish = false
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+protocol = { path = "../protocol" }
+filters = { path = "../filters" }
+
+[[bin]]
+name = "protocol_frame_decode_fuzz"
+path = "fuzz_targets/protocol_frame_decode_fuzz.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "filters_parse_fuzz"
+path = "fuzz_targets/filters_parse_fuzz.rs"
+test = false
+doc = false

--- a/crates/fuzz/fuzz_targets/filters_parse_fuzz.rs
+++ b/crates/fuzz/fuzz_targets/filters_parse_fuzz.rs
@@ -1,0 +1,9 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+use filters::filters;
+
+fuzz_target!(|data: &[u8]| {
+    if let Ok(s) = std::str::from_utf8(data) {
+        let _ = filters::parse(s);
+    }
+});

--- a/crates/fuzz/fuzz_targets/protocol_frame_decode_fuzz.rs
+++ b/crates/fuzz/fuzz_targets/protocol_frame_decode_fuzz.rs
@@ -1,0 +1,8 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+use protocol::protocol::Frame;
+use std::io::Cursor;
+
+fuzz_target!(|data: &[u8]| {
+    let _ = Frame::decode(&mut Cursor::new(data));
+});

--- a/crates/fuzz/tests/placeholder.rs
+++ b/crates/fuzz/tests/placeholder.rs
@@ -1,0 +1,4 @@
+#[test]
+fn placeholder() {
+    assert_eq!(2 + 2, 4);
+}

--- a/crates/meta/tests/placeholder.rs
+++ b/crates/meta/tests/placeholder.rs
@@ -1,0 +1,4 @@
+#[test]
+fn placeholder() {
+    assert_eq!(2 + 2, 4);
+}

--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -139,3 +139,4 @@ mod tests {
         assert_eq!(msg2, Message::KeepAlive);
     }
 }
+}

--- a/crates/protocol/tests/placeholder.rs
+++ b/crates/protocol/tests/placeholder.rs
@@ -1,0 +1,4 @@
+#[test]
+fn placeholder() {
+    assert_eq!(2 + 2, 4);
+}

--- a/crates/transport/tests/placeholder.rs
+++ b/crates/transport/tests/placeholder.rs
@@ -1,0 +1,4 @@
+#[test]
+fn placeholder() {
+    assert_eq!(2 + 2, 4);
+}

--- a/crates/walk/tests/placeholder.rs
+++ b/crates/walk/tests/placeholder.rs
@@ -1,0 +1,4 @@
+#[test]
+fn placeholder() {
+    assert_eq!(2 + 2, 4);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,8 +2,8 @@ use std::fs;
 use std::path::Path;
 
 use anyhow::Result;
-use checksums::{rolling_checksum, strong_digest};
-use protocol::{negotiate_version, Message, LATEST_VERSION};
+use checksums::checksums::{rolling_checksum, strong_digest};
+use protocol::protocol::{negotiate_version, Message, LATEST_VERSION};
 
 /// Synchronize a single file from `src` to `dst` using the local protocol.
 pub fn synchronize(src: &Path, dst: &Path) -> Result<()> {


### PR DESCRIPTION
## Summary
- add placeholder tests for each crate
- scaffold cargo-fuzz targets for protocol frame decoding and filter parsing
- document how to run tests and fuzzers

## Testing
- `cargo test`
- `cargo fuzz list --fuzz-dir crates/fuzz`


------
https://chatgpt.com/codex/tasks/task_e_68af01ef00188323b5f1f4bfe9e30ada