### PR TITLE
Flatten protocol and checksums modules

### DIFF
--- a/crates/checksums/src/lib.rs
+++ b/crates/checksums/src/lib.rs
@@ -1,4 +1,3 @@
-pub mod checksums {
 use md5::{Digest, Md5};
 
 /// Compute the rsync rolling checksum for a block of data.
@@ -23,7 +22,11 @@ pub struct Rolling {
 
 impl Rolling {
     pub fn new(block: &[u8]) -> Self {
-        let mut r = Rolling { len: block.len(), s1: 0, s2: 0 };
+        let mut r = Rolling {
+            len: block.len(),
+            s1: 0,
+            s2: 0,
+        };
         for (i, b) in block.iter().enumerate() {
             r.s1 = r.s1.wrapping_add(*b as u32);
             r.s2 = r.s2.wrapping_add((block.len() - i) as u32 * (*b as u32));
@@ -33,7 +36,10 @@ impl Rolling {
 
     pub fn roll(&mut self, out: u8, inp: u8) {
         self.s1 = self.s1.wrapping_sub(out as u32).wrapping_add(inp as u32);
-        self.s2 = self.s2.wrapping_sub(self.len as u32 * out as u32).wrapping_add(self.s1);
+        self.s2 = self
+            .s2
+            .wrapping_sub(self.len as u32 * out as u32)
+            .wrapping_add(self.s1);
     }
 
     pub fn digest(&self) -> u32 {
@@ -73,5 +79,4 @@ mod tests {
         let digest = strong_digest(b"hello world");
         assert_eq!(hex::encode(digest), "5eb63bbbe01eeed093cb22bb8f5acdc3");
     }
-}
 }

--- a/crates/fuzz/fuzz_targets/filters_parse_fuzz.rs
+++ b/crates/fuzz/fuzz_targets/filters_parse_fuzz.rs
@@ -1,6 +1,6 @@
 #![no_main]
-use libfuzzer_sys::fuzz_target;
 use filters::filters;
+use libfuzzer_sys::fuzz_target;
 
 fuzz_target!(|data: &[u8]| {
     if let Ok(s) = std::str::from_utf8(data) {

--- a/crates/fuzz/fuzz_targets/protocol_frame_decode_fuzz.rs
+++ b/crates/fuzz/fuzz_targets/protocol_frame_decode_fuzz.rs
@@ -1,6 +1,6 @@
 #![no_main]
 use libfuzzer_sys::fuzz_target;
-use protocol::protocol::Frame;
+use protocol::Frame;
 use std::io::Cursor;
 
 fuzz_target!(|data: &[u8]| {

--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -1,6 +1,3 @@
-
-pub mod protocol {
-    // Placeholder for the protocol crate.
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 use std::io::{self, Read, Write};
 
@@ -12,7 +9,8 @@ pub const LATEST_VERSION: u32 = 31;
 pub fn negotiate_version(peer: u32) -> Option<u32> {
     if peer >= LATEST_VERSION {
         Some(LATEST_VERSION)
-    } else if peer >= 29 { // minimum we support
+    } else if peer >= 29 {
+        // minimum we support
         Some(peer)
     } else {
         None
@@ -59,7 +57,11 @@ impl Frame {
         let len = r.read_u32::<BigEndian>()? as usize;
         let mut payload = vec![0; len];
         r.read_exact(&mut payload)?;
-        Ok(Frame { channel, tag, payload })
+        Ok(Frame {
+            channel,
+            tag,
+            payload,
+        })
     }
 }
 
@@ -78,11 +80,27 @@ impl Message {
             Message::Version(v) => {
                 let mut payload = Vec::new();
                 payload.write_u32::<BigEndian>(*v).unwrap();
-                Frame { channel, tag: Tag::Message, payload }
+                Frame {
+                    channel,
+                    tag: Tag::Message,
+                    payload,
+                }
             }
-            Message::Data(data) => Frame { channel, tag: Tag::Message, payload: data.clone() },
-            Message::Done => Frame { channel, tag: Tag::Message, payload: vec![] },
-            Message::KeepAlive => Frame { channel, tag: Tag::KeepAlive, payload: vec![] },
+            Message::Data(data) => Frame {
+                channel,
+                tag: Tag::Message,
+                payload: data.clone(),
+            },
+            Message::Done => Frame {
+                channel,
+                tag: Tag::Message,
+                payload: vec![],
+            },
+            Message::KeepAlive => Frame {
+                channel,
+                tag: Tag::KeepAlive,
+                payload: vec![],
+            },
         }
     }
 
@@ -138,5 +156,4 @@ mod tests {
         let msg2 = Message::from_frame(decoded).unwrap();
         assert_eq!(msg2, Message::KeepAlive);
     }
-}
 }

--- a/src/bin/rsync-rs.rs
+++ b/src/bin/rsync-rs.rs
@@ -26,7 +26,11 @@ enum Commands {
 fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
     match cli.command {
-        Commands::Client { local: true, src, dst } => {
+        Commands::Client {
+            local: true,
+            src,
+            dst,
+        } => {
             rsync_rs::synchronize(&src, &dst)?;
         }
         _ => {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -9,7 +9,12 @@ fn client_local_sync() {
     std::fs::write(&src, b"hello world").unwrap();
 
     let mut cmd = Command::cargo_bin("rsync-rs").unwrap();
-    cmd.args(["client", "--local", src.to_str().unwrap(), dst.to_str().unwrap()]);
+    cmd.args([
+        "client",
+        "--local",
+        src.to_str().unwrap(),
+        dst.to_str().unwrap(),
+    ]);
     cmd.assert().success();
 
     let out = std::fs::read(&dst).unwrap();


### PR DESCRIPTION
## Summary
- inline protocol and checksums modules at their crate roots
- update imports to use new module layout

## Testing
- `cargo test --workspace`
- `cargo test -p protocol`


------
https://chatgpt.com/codex/tasks/task_e_68af044395f483238edcf5a7c4044c22