### PR TITLE
Add channel mux/demux with keepalive handling

### DIFF
--- a/crates/protocol/src/demux.rs
+++ b/crates/protocol/src/demux.rs
@@ -1,0 +1,69 @@
+use std::collections::HashMap;
+use std::sync::mpsc::{self, Receiver, Sender};
+use std::time::{Duration, Instant};
+
+use crate::{Frame, Message};
+
+struct Channel {
+    sender: Sender<Message>,
+    last_recv: Instant,
+}
+
+/// Demultiplex incoming frames to per-channel message queues and monitor peer
+/// liveness.
+pub struct Demux {
+    timeout: Duration,
+    channels: HashMap<u16, Channel>,
+}
+
+impl Demux {
+    /// Create a new demultiplexer with the specified peer timeout.
+    pub fn new(timeout: Duration) -> Self {
+        Demux { timeout, channels: HashMap::new() }
+    }
+
+    /// Register a channel and obtain a [`Receiver`] for reading decoded
+    /// messages.
+    pub fn register_channel(&mut self, id: u16) -> Receiver<Message> {
+        let (tx, rx) = mpsc::channel();
+        let ch = Channel { sender: tx, last_recv: Instant::now() };
+        self.channels.insert(id, ch);
+        rx
+    }
+
+    /// Process an incoming [`Frame`]. Keep-alive frames simply refresh the
+    /// channel's activity timestamp while other messages are forwarded to the
+    /// appropriate receiver.
+    pub fn ingest(&mut self, frame: Frame) -> std::io::Result<()> {
+        let id = frame.header.channel;
+        let msg = Message::from_frame(frame)?;
+
+        if let Some(ch) = self.channels.get_mut(&id) {
+            ch.last_recv = Instant::now();
+            if msg != Message::KeepAlive {
+                ch.sender
+                    .send(msg)
+                    .map_err(|_| std::io::Error::new(std::io::ErrorKind::BrokenPipe, "channel closed"))?;
+            }
+            Ok(())
+        } else {
+            Err(std::io::Error::new(std::io::ErrorKind::InvalidData, "unknown channel"))
+        }
+    }
+
+    /// Check for channels that have not received any frames within the timeout
+    /// period. Returns an error if a timeout is detected.
+    pub fn poll(&mut self) -> std::io::Result<()> {
+        let now = Instant::now();
+        for (&id, ch) in self.channels.iter() {
+            if now.duration_since(ch.last_recv) > self.timeout {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::TimedOut,
+                    format!("channel {} timed out", id),
+                ));
+            }
+        }
+        Ok(())
+    }
+}
+

--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -3,6 +3,9 @@ use std::convert::TryFrom;
 use std::fmt;
 use std::io::{self, Read, Write};
 
+pub mod mux;
+pub mod demux;
+
 /// Latest protocol version supported by this implementation.
 pub const LATEST_VERSION: u32 = 31;
 /// Oldest protocol version we support.

--- a/crates/protocol/src/mux.rs
+++ b/crates/protocol/src/mux.rs
@@ -1,0 +1,80 @@
+use std::collections::HashMap;
+use std::sync::mpsc::{self, Receiver, Sender, TryRecvError};
+use std::time::{Duration, Instant};
+
+use crate::{Frame, Message};
+
+struct Channel {
+    sender: Sender<Message>,
+    receiver: Receiver<Message>,
+    last_sent: Instant,
+}
+
+/// Multiplex messages from multiple channels into a single frame stream.
+///
+/// Each registered channel is associated with a [`Sender`] returned by
+/// [`Mux::register_channel`]. Messages sent through these senders are converted
+/// into [`Frame`]s when [`Mux::poll`] is invoked. If a channel is idle for
+/// longer than the configured keepalive interval a [`Message::KeepAlive`] frame
+/// is emitted.
+pub struct Mux {
+    keepalive: Duration,
+    channels: HashMap<u16, Channel>,
+}
+
+impl Mux {
+    /// Create a new multiplexer with the specified keepalive interval.
+    pub fn new(keepalive: Duration) -> Self {
+        Mux { keepalive, channels: HashMap::new() }
+    }
+
+    /// Register a new channel and return a [`Sender`] for queuing messages.
+    pub fn register_channel(&mut self, id: u16) -> Sender<Message> {
+        let (tx, rx) = mpsc::channel();
+        let ch = Channel { sender: tx.clone(), receiver: rx, last_sent: Instant::now() };
+        self.channels.insert(id, ch);
+        tx
+    }
+
+    /// Queue a message to be sent on the given channel.
+    pub fn send(&self, id: u16, msg: Message) -> Result<(), mpsc::SendError<Message>> {
+        if let Some(ch) = self.channels.get(&id) {
+            ch.sender.send(msg)
+        } else {
+            Err(mpsc::SendError(msg))
+        }
+    }
+
+    /// Poll all registered channels for outgoing frames. The first available
+    /// message is converted into a [`Frame`] and returned. If no messages are
+    /// pending, idle channels may generate keepalive frames.
+    pub fn poll(&mut self) -> Option<Frame> {
+        let now = Instant::now();
+
+        for (&id, ch) in self.channels.iter_mut() {
+            match ch.receiver.try_recv() {
+                Ok(msg) => {
+                    ch.last_sent = now;
+                    return Some(msg.to_frame(id));
+                }
+                Err(TryRecvError::Empty) => {
+                    if now.duration_since(ch.last_sent) >= self.keepalive {
+                        ch.last_sent = now;
+                        return Some(Message::KeepAlive.to_frame(id));
+                    }
+                }
+                Err(TryRecvError::Disconnected) => {
+                    // If the sender has gone away, treat as idle and emit
+                    // keepalives until the channel is dropped.
+                    if now.duration_since(ch.last_sent) >= self.keepalive {
+                        ch.last_sent = now;
+                        return Some(Message::KeepAlive.to_frame(id));
+                    }
+                }
+            }
+        }
+
+        None
+    }
+}
+

--- a/crates/protocol/tests/mux_demux.rs
+++ b/crates/protocol/tests/mux_demux.rs
@@ -1,0 +1,59 @@
+use std::thread::sleep;
+use std::time::Duration;
+
+use protocol::{demux::Demux, mux::Mux, Message};
+
+#[test]
+fn multiplex_multiple_channels() {
+    let mut mux = Mux::new(Duration::from_millis(50));
+    let mut demux = Demux::new(Duration::from_millis(100));
+
+    let tx1 = mux.register_channel(1);
+    let tx2 = mux.register_channel(2);
+    let rx1 = demux.register_channel(1);
+    let rx2 = demux.register_channel(2);
+
+    tx1.send(Message::Data(b"one".to_vec())).unwrap();
+    tx2.send(Message::Data(b"two".to_vec())).unwrap();
+
+    // Collect two frames from the multiplexer
+    let mut frames = Vec::new();
+    while frames.len() < 2 {
+        if let Some(frame) = mux.poll() {
+            frames.push(frame);
+        }
+    }
+
+    for frame in frames {
+        demux.ingest(frame).unwrap();
+    }
+
+    assert_eq!(rx1.try_recv().unwrap(), Message::Data(b"one".to_vec()));
+    assert_eq!(rx2.try_recv().unwrap(), Message::Data(b"two".to_vec()));
+}
+
+#[test]
+fn keepalive_and_timeout() {
+    let keepalive = Duration::from_millis(10);
+    let timeout = Duration::from_millis(30);
+    let mut mux = Mux::new(keepalive);
+    let mut demux = Demux::new(timeout);
+
+    // Register channel 0
+    let _tx = mux.register_channel(0);
+    let _rx = demux.register_channel(0);
+
+    // No data is sent, after the keepalive interval the mux should emit a keepalive
+    sleep(Duration::from_millis(20));
+    let frame = mux.poll().expect("keepalive frame");
+    demux.ingest(frame).unwrap();
+
+    // Keepalive resets timer; no timeout yet
+    sleep(Duration::from_millis(10));
+    assert!(demux.poll().is_ok());
+
+    // Without further frames we should eventually time out
+    sleep(Duration::from_millis(40));
+    assert!(demux.poll().is_err());
+}
+


### PR DESCRIPTION
## Summary
- add mux and demux modules for channel-based message routing
- emit keep-alive frames when idle and error on peer timeout
- test multiplexing, keep-alive, and timeout behavior

## Testing
- `cargo test -p protocol`

------
https://chatgpt.com/codex/tasks/task_e_68af161252548323af645bd505bcca77