### PR TITLE
Add blocking local transport wrapper with tests

### DIFF
--- a/crates/transport/src/lib.rs
+++ b/crates/transport/src/lib.rs
@@ -1,3 +1,46 @@
-pub mod transport {
-    // Placeholder for the transport crate.
+use std::io::{self, Read, Write};
+
+/// Trait representing a blocking transport.
+pub trait Transport {
+    /// Send data over the transport.
+    fn send(&mut self, data: &[u8]) -> io::Result<()>;
+
+    /// Receive data from the transport into the provided buffer.
+    ///
+    /// Returns the number of bytes read.
+    fn receive(&mut self, buf: &mut [u8]) -> io::Result<usize>;
 }
+
+/// Transport implementation over local pipes using blocking I/O.
+pub struct LocalPipeTransport<R, W> {
+    reader: R,
+    writer: W,
+}
+
+impl<R, W> LocalPipeTransport<R, W> {
+    /// Create a new transport from the given reader and writer.
+    pub fn new(reader: R, writer: W) -> Self {
+        Self { reader, writer }
+    }
+
+    /// Consume the transport and return the underlying reader and writer.
+    pub fn into_inner(self) -> (R, W) {
+        (self.reader, self.writer)
+    }
+}
+
+impl<R: Read, W: Write> Transport for LocalPipeTransport<R, W> {
+    fn send(&mut self, data: &[u8]) -> io::Result<()> {
+        self.writer.write_all(data)
+    }
+
+    fn receive(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        self.reader.read(buf)
+    }
+}
+
+/// Marker trait for transports carried over SSH.
+pub trait SshTransport: Transport {}
+
+/// Marker trait for transports that connect to an rsync daemon.
+pub trait DaemonTransport: Transport {}

--- a/crates/transport/tests/local_pipe.rs
+++ b/crates/transport/tests/local_pipe.rs
@@ -1,0 +1,28 @@
+use std::io::Cursor;
+
+use transport::{LocalPipeTransport, Transport};
+
+#[test]
+fn send_writes_to_writer() {
+    let reader = Cursor::new(Vec::new());
+    let writer = Cursor::new(Vec::new());
+    let mut transport = LocalPipeTransport::new(reader, writer);
+
+    transport.send(b"hello").expect("send should succeed");
+
+    let (_, writer) = transport.into_inner();
+    assert_eq!(writer.into_inner(), b"hello");
+}
+
+#[test]
+fn receive_reads_from_reader() {
+    let reader = Cursor::new(b"world".to_vec());
+    let writer = Cursor::new(Vec::new());
+    let mut transport = LocalPipeTransport::new(reader, writer);
+
+    let mut buf = [0u8; 5];
+    let n = transport.receive(&mut buf).expect("receive should succeed");
+
+    assert_eq!(n, 5);
+    assert_eq!(&buf, b"world");
+}

--- a/crates/transport/tests/placeholder.rs
+++ b/crates/transport/tests/placeholder.rs
@@ -1,4 +1,0 @@
-#[test]
-fn placeholder() {
-    assert_eq!(2 + 2, 4);
-}


### PR DESCRIPTION
## Summary
- implement simple blocking transport over local Read/Write pipes
- define marker traits for future SSH and daemon transports
- add in-memory tests for send and receive paths

## Testing
- `cargo test -p transport`


------
https://chatgpt.com/codex/tasks/task_e_68af216863348323926a089b791c4d53