### PR TITLE
Fail on unsupported client mode

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -31,10 +31,14 @@ enum Commands {
 pub fn run() -> Result<()> {
     let cli = Cli::parse();
     match cli.command {
-        Commands::Client { local: true, src, dst } => {
+        Commands::Client {
+            local: true,
+            src,
+            dst,
+        } => {
             sync(&src, &dst)?;
         }
-        _ => eprintln!("Only local client mode is implemented"),
+        _ => anyhow::bail!("Only local client mode is implemented"),
     }
     Ok(())
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -21,3 +21,19 @@ fn client_local_sync() {
     let out = std::fs::read(dst_dir.join("a.txt")).unwrap();
     assert_eq!(out, b"hello world");
 }
+
+#[test]
+fn unsupported_subcommand() {
+    let dir = tempdir().unwrap();
+    let src_dir = dir.path().join("src");
+    let dst_dir = dir.path().join("dst");
+    std::fs::create_dir_all(&src_dir).unwrap();
+
+    let mut cmd = Command::cargo_bin("rsync-rs").unwrap();
+    cmd.args([
+        "client",
+        src_dir.to_str().unwrap(),
+        dst_dir.to_str().unwrap(),
+    ]);
+    cmd.assert().failure();
+}


### PR DESCRIPTION
## Summary
- error out when client subcommand is used without `--local`
- test unsupported subcommand path returns failure

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68af32f64ac4832388bc4503dfb8051e