### PR TITLE
feat: add clap-based CLI with stub subcommands

### DIFF
--- a/bin/rsync-rs/src/main.rs
+++ b/bin/rsync-rs/src/main.rs
@@ -42,6 +42,18 @@ mod tests {
     }
 
     #[test]
+    fn parses_daemon_subcommand() {
+        let cli = Cli::try_parse_from(["rsync-rs", "daemon"]).unwrap();
+        assert!(matches!(cli.command, Commands::Daemon));
+    }
+
+    #[test]
+    fn parses_probe_subcommand() {
+        let cli = Cli::try_parse_from(["rsync-rs", "probe"]).unwrap();
+        assert!(matches!(cli.command, Commands::Probe));
+    }
+
+    #[test]
     fn help_mentions_subcommands() {
         let mut cmd = Cli::command();
         let help = cmd.render_long_help().to_string();


### PR DESCRIPTION
## Summary
- implement a clap-driven `rsync-rs` binary with `client`, `daemon`, and `probe` subcommands
- hook subcommands to stub handlers in `cli` crate
- add unit tests covering argument parsing and help output

## Testing
- `cargo test --locked`
- `cargo test --locked --manifest-path bin/rsync-rs/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_68af6099d2748323b4aaea52267b7660