### PR TITLE
Implement rsync-style filter parsing and matching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -299,6 +308,9 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 [[package]]
 name = "filters"
 version = "0.1.0"
+dependencies = [
+ "globset",
+]
 
 [[package]]
 name = "fuzz"
@@ -329,6 +341,19 @@ dependencies = [
  "libc",
  "r-efi",
  "wasi",
+]
+
+[[package]]
+name = "globset"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54a1028dfc5f5df5da8a56a73e6c153c9a9708ec57232470703592a3f18e49f5"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -380,6 +405,12 @@ name = "linux-raw-sys"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+
+[[package]]
+name = "log"
+version = "0.4.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "md-5"
@@ -476,6 +507,17 @@ name = "regex-automata"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b9458fa0bfeeac22b5ca447c63aaf45f28439a709ccd244698632f9aa6394d6"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 
 [[package]]
 name = "rsync-rs"

--- a/crates/filters/Cargo.toml
+++ b/crates/filters/Cargo.toml
@@ -2,3 +2,6 @@
 name = "filters"
 version = "0.1.0"
 edition = "2021"
+
+[dependencies]
+globset = "0.4"

--- a/crates/filters/src/lib.rs
+++ b/crates/filters/src/lib.rs
@@ -1,9 +1,99 @@
 pub mod filters {
-    // Placeholder for the filters crate.
+    use globset::{Glob, GlobMatcher};
+    use std::path::Path;
+
+    /// A single include or exclude rule compiled into a glob matcher.
+    #[derive(Clone)]
+    pub enum Rule {
+        Include(GlobMatcher),
+        Exclude(GlobMatcher),
+    }
+
+    impl Rule {
+        fn matches<P: AsRef<Path>>(&self, path: P) -> bool {
+            match self {
+                Rule::Include(m) | Rule::Exclude(m) => m.is_match(path),
+            }
+        }
+
+        fn is_include(&self) -> bool {
+            matches!(self, Rule::Include(_))
+        }
+    }
+
+    /// Matcher evaluates rules sequentially against paths.
+    #[derive(Clone, Default)]
+    pub struct Matcher {
+        rules: Vec<Rule>,
+    }
+
+    impl Matcher {
+        pub fn new(rules: Vec<Rule>) -> Self {
+            Self { rules }
+        }
+
+        /// Determine if the provided path is included by the rules.
+        pub fn is_included<P: AsRef<Path>>(&self, path: P) -> bool {
+            let path = path.as_ref();
+            for rule in &self.rules {
+                if rule.matches(path) {
+                    return rule.is_include();
+                }
+            }
+            true
+        }
+
+        /// Merge additional rules, as when reading a per-directory `.rsync-filter`.
+        pub fn merge(&mut self, more: Vec<Rule>) {
+            self.rules.extend(more);
+        }
+    }
+
+    #[derive(Debug)]
+    pub enum ParseError {
+        InvalidRule(String),
+        Glob(globset::Error),
+    }
+
+    impl From<globset::Error> for ParseError {
+        fn from(e: globset::Error) -> Self {
+            Self::Glob(e)
+        }
+    }
+
+    enum RuleKind {
+        Include,
+        Exclude,
+    }
 
     /// Parse filter rules from input.
-    pub fn parse(_input: &str) -> Result<(), &'static str> {
-        // Placeholder parser implementation
-        Ok(())
+    pub fn parse(input: &str) -> Result<Vec<Rule>, ParseError> {
+        let mut rules = Vec::new();
+
+        for raw_line in input.lines() {
+            let line = raw_line.trim();
+            if line.is_empty() || line.starts_with('#') {
+                continue;
+            }
+
+            let (kind, pattern) = match line.chars().next() {
+                Some('+') => (RuleKind::Include, line[1..].trim_start()),
+                Some('-') => (RuleKind::Exclude, line[1..].trim_start()),
+                _ => return Err(ParseError::InvalidRule(raw_line.to_string())),
+            };
+
+            if pattern.is_empty() {
+                return Err(ParseError::InvalidRule(raw_line.to_string()));
+            }
+
+            let matcher = Glob::new(pattern)?.compile_matcher();
+
+            match kind {
+                RuleKind::Include => rules.push(Rule::Include(matcher)),
+                RuleKind::Exclude => rules.push(Rule::Exclude(matcher)),
+            }
+        }
+
+        Ok(rules)
     }
 }

--- a/crates/filters/tests/include_exclude.rs
+++ b/crates/filters/tests/include_exclude.rs
@@ -1,0 +1,11 @@
+use filters::filters::{parse, Matcher};
+
+#[test]
+fn include_and_exclude() {
+    let rules = parse("+ special.tmp\n- *.tmp\n").expect("parse");
+    let matcher = Matcher::new(rules);
+
+    assert!(matcher.is_included("special.tmp"));
+    assert!(!matcher.is_included("other.tmp"));
+    assert!(matcher.is_included("notes.txt"));
+}

--- a/crates/filters/tests/merge.rs
+++ b/crates/filters/tests/merge.rs
@@ -1,0 +1,17 @@
+use filters::filters::{parse, Matcher};
+
+#[test]
+fn rsync_filter_merge() {
+    let root_rules = parse("- *.tmp\n").unwrap();
+    let mut matcher = Matcher::new(root_rules);
+
+    assert!(matcher.is_included("notes.txt"));
+    assert!(!matcher.is_included("junk.tmp"));
+
+    // Merge rules from a subdirectory `.rsync-filter` file
+    let sub_rules = parse("- secret\n").unwrap();
+    matcher.merge(sub_rules);
+
+    assert!(!matcher.is_included("junk.tmp"));
+    assert!(!matcher.is_included("secret"));
+}

--- a/crates/filters/tests/placeholder.rs
+++ b/crates/filters/tests/placeholder.rs
@@ -1,4 +1,0 @@
-#[test]
-fn placeholder() {
-    assert_eq!(2 + 2, 4);
-}


### PR DESCRIPTION
## Summary
- add glob-based rule parser and matcher for filters
- support merging of per-directory `.rsync-filter` rules
- test include/exclude behavior and rule merging

## Testing
- `cargo test -p filters`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68afd894b8cc8323883c1af52cab8cee