### PR TITLE
Implement rsync filter parsing with matcher and tests

### DIFF
--- a/crates/filters/src/lib.rs
+++ b/crates/filters/src/lib.rs
@@ -76,10 +76,15 @@ pub mod filters {
                 continue;
             }
 
-            let (kind, pattern) = match line.chars().next() {
-                Some('+') => (RuleKind::Include, line[1..].trim_start()),
-                Some('-') => (RuleKind::Exclude, line[1..].trim_start()),
-                _ => return Err(ParseError::InvalidRule(raw_line.to_string())),
+            // Determine rule type based on the first character. Using
+            // `strip_prefix` keeps the logic simple and avoids manual
+            // character indexing.
+            let (kind, pattern) = if let Some(rest) = line.strip_prefix('+') {
+                (RuleKind::Include, rest.trim_start())
+            } else if let Some(rest) = line.strip_prefix('-') {
+                (RuleKind::Exclude, rest.trim_start())
+            } else {
+                return Err(ParseError::InvalidRule(raw_line.to_string()));
             };
 
             if pattern.is_empty() {

--- a/crates/filters/tests/comments.rs
+++ b/crates/filters/tests/comments.rs
@@ -1,0 +1,11 @@
+use filters::filters::{parse, Matcher};
+
+#[test]
+fn comments_and_blank_lines_are_ignored() {
+    // Leading comment and blank line should be ignored by the parser
+    let rules = parse("# initial comment\n\n+ keep.log\n- *.log\n").expect("parse");
+    let matcher = Matcher::new(rules);
+
+    assert!(matcher.is_included("keep.log"));
+    assert!(!matcher.is_included("debug.log"));
+}


### PR DESCRIPTION
## Summary
- parse rsync-style `+` and `-` filter rules into glob matchers
- evaluate filter rules sequentially and support merging rule sets
- exercise include/exclude logic and `.rsync-filter` merging, including comment handling

## Testing
- `cargo test -p filters`


------
https://chatgpt.com/codex/tasks/task_e_68b007f19120832385c32912cbbc074e