### PR TITLE
Add fuzzing helpers and CI smoke tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,7 @@ jobs:
           override: true
 
       - name: Run fuzzers briefly
+        # A single iteration is enough to ensure the harnesses compile and link.
         run: |
           cargo run -p fuzz --bin protocol_frame_decode_fuzz -- -runs=1
           cargo run -p fuzz --bin filters_parse_fuzz -- -runs=1

--- a/crates/fuzz/src/lib.rs
+++ b/crates/fuzz/src/lib.rs
@@ -13,6 +13,7 @@ pub mod helpers {
     /// Many fuzz targets operate on types that expect an `io::Read`
     /// implementation.  A `Cursor` over the input bytes satisfies that
     /// requirement without allocating.
+    #[inline]
     pub fn cursor(data: &[u8]) -> Cursor<&[u8]> {
         Cursor::new(data)
     }
@@ -21,6 +22,7 @@ pub mod helpers {
     ///
     /// Returning `None` instead of panicking keeps fuzz targets simple
     /// when they need optional textual input.
+    #[inline]
     pub fn as_str(data: &[u8]) -> Option<&str> {
         std::str::from_utf8(data).ok()
     }

--- a/docs/fuzzing.md
+++ b/docs/fuzzing.md
@@ -21,6 +21,14 @@ arguments after `--` to libFuzzer.  `-max_total_time` limits the run so
 these can execute in CI without timing out.  For longer fuzzing sessions
 use release mode (`--release`) and a longer time budget.
 
+To simply verify that the harnesses build, the CI pipeline executes each
+fuzzer for a single iteration:
+
+```bash
+cargo run -p fuzz --bin protocol_frame_decode_fuzz -- -runs=1
+cargo run -p fuzz --bin filters_parse_fuzz -- -runs=1
+```
+
 ## Adding a new corpus
 
 Fuzzers expect input corpora in the directory specified on the command


### PR DESCRIPTION
## Summary
- add inline helper utilities for fuzz targets
- expand documentation on running fuzzers and CI behavior
- clarify CI job that smoke tests fuzzers

## Testing
- `cargo test`
- `cargo run -p fuzz --bin protocol_frame_decode_fuzz -- -runs=1`
- `cargo run -p fuzz --bin filters_parse_fuzz -- -runs=1`


------
https://chatgpt.com/codex/tasks/task_e_68b0110304548323816ca7826bb2a295