### PR TITLE
Add remote sync handling and probing to CLI

### DIFF
--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -23,7 +23,7 @@ fn client_local_sync() {
 }
 
 #[test]
-fn unsupported_subcommand() {
+fn local_sync_without_flag_fails() {
     let dir = tempdir().unwrap();
     let src_dir = dir.path().join("src");
     let dst_dir = dir.path().join("dst");
@@ -39,17 +39,23 @@ fn unsupported_subcommand() {
 }
 
 #[test]
-fn remote_destination_is_unsupported() {
+fn remote_destination_syncs() {
     let dir = tempdir().unwrap();
     let src_dir = dir.path().join("src");
+    let dst_dir = dir.path().join("remote_dst");
     std::fs::create_dir_all(&src_dir).unwrap();
     std::fs::write(src_dir.join("file.txt"), b"hello").unwrap();
+
+    let dst_spec = format!("remote:{}", dst_dir.to_str().unwrap());
 
     let mut cmd = Command::cargo_bin("rsync-rs").unwrap();
     cmd.args([
         "client",
         src_dir.to_str().unwrap(),
-        "remote:/dest",
+        &dst_spec,
     ]);
-    cmd.assert().failure();
+    cmd.assert().success();
+
+    let out = std::fs::read(dst_dir.join("file.txt")).unwrap();
+    assert_eq!(out, b"hello");
 }

--- a/tests/daemon_probe.rs
+++ b/tests/daemon_probe.rs
@@ -1,5 +1,8 @@
 use assert_cmd::Command;
 use predicates::str::contains;
+use std::io::{Read, Write};
+use std::net::TcpListener;
+use std::thread;
 
 #[test]
 fn daemon_accepts_modules() {
@@ -15,6 +18,26 @@ fn daemon_accepts_modules() {
 fn probe_reports_version() {
     let mut cmd = Command::cargo_bin("rsync-rs").unwrap();
     cmd.args(["probe"]);
+    cmd.assert()
+        .success()
+        .stdout(contains("negotiated version"))
+        .stderr("");
+}
+
+#[test]
+fn probe_connects_to_peer() {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+    thread::spawn(move || {
+        if let Ok((mut stream, _)) = listener.accept() {
+            let mut buf = [0u8; 4];
+            stream.read_exact(&mut buf).unwrap();
+            stream.write_all(&protocol::LATEST_VERSION.to_be_bytes()).unwrap();
+        }
+    });
+
+    let mut cmd = Command::cargo_bin("rsync-rs").unwrap();
+    cmd.args(["probe", &addr.to_string()]);
     cmd.assert()
         .success()
         .stdout(contains("negotiated version"))


### PR DESCRIPTION
## Summary
- support remote source or destination specs in `rsync-rs client`
- allow `probe` subcommand to connect to a peer and negotiate protocol version
- expand integration tests for remote sync and network probing

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68b0150bcb888323a27bb697e229ff1f