### PR TITLE
Remove placeholder fuzz test

### DIFF
--- a/crates/fuzz/tests/placeholder.rs
+++ b/crates/fuzz/tests/placeholder.rs
@@ -1,4 +1,0 @@
-#[test]
-fn placeholder() {
-    assert_eq!(2 + 2, 4);
-}


### PR DESCRIPTION
## Summary
- remove placeholder test from fuzz crate
- verify fuzz targets compile and run

## Testing
- `cargo test -p fuzz --tests`
- `cargo run -p fuzz --bin filters_parse_fuzz -- -runs=1`
- `cargo run -p fuzz --bin protocol_frame_decode_fuzz -- -runs=1`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b01eb2a1c883239f4c56ed2467a10c