### PR TITLE
Propagate directory walk errors

### DIFF
--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -221,7 +221,8 @@ pub fn sync(src: &Path, dst: &Path) -> Result<()> {
     let mut sender = Sender::new(1024);
     let mut receiver = Receiver::new();
     sender.start();
-    for (path, file_type) in walk(src) {
+    for entry in walk(src) {
+        let (path, file_type) = entry?;
         if let Ok(rel) = path.strip_prefix(src) {
             let dest_path = dst.join(rel);
             if file_type.is_file() {

--- a/crates/walk/src/lib.rs
+++ b/crates/walk/src/lib.rs
@@ -1,12 +1,15 @@
 use std::fs::FileType;
 use std::path::{Path, PathBuf};
+use walkdir::Error;
 
 /// Walk a directory tree yielding paths and their file types.
 ///
 /// This is a thin wrapper around the `walkdir` crate that exposes all entries
-/// (files, directories, and symlinks) along with their [`FileType`].
-pub fn walk(root: impl AsRef<Path>) -> impl Iterator<Item = (PathBuf, FileType)> {
+/// (files, directories, and symlinks) along with their [`FileType`]. Unlike the
+/// previous implementation, this returns [`Result`] items so callers can handle
+/// traversal errors instead of silently discarding them.
+pub fn walk(root: impl AsRef<Path>) -> impl Iterator<Item = Result<(PathBuf, FileType), Error>> {
     walkdir::WalkDir::new(root)
         .into_iter()
-        .filter_map(|e| e.ok().map(|entry| (entry.path().to_path_buf(), entry.file_type())))
+        .map(|e| e.map(|entry| (entry.path().to_path_buf(), entry.file_type())))
 }

--- a/crates/walk/tests/walk.rs
+++ b/crates/walk/tests/walk.rs
@@ -1,6 +1,6 @@
+use std::fs;
 use tempfile::tempdir;
 use walk::walk;
-use std::fs;
 
 #[cfg(unix)]
 use std::os::unix::fs::symlink;
@@ -20,10 +20,18 @@ fn walk_includes_files_dirs_and_symlinks() {
     #[cfg(windows)]
     symlink_file(root.join("top.txt"), &link_path).unwrap();
 
-    let entries: Vec<_> = walk(root).collect();
+    let entries: Vec<_> = walk(root).collect::<Result<Vec<_>, _>>().unwrap();
     assert!(entries.iter().any(|(p, t)| p == &root && t.is_dir()));
-    assert!(entries.iter().any(|(p, t)| p == &root.join("dir") && t.is_dir()));
-    assert!(entries.iter().any(|(p, t)| p == &root.join("dir/file.txt") && t.is_file()));
-    assert!(entries.iter().any(|(p, t)| p == &root.join("top.txt") && t.is_file()));
-    assert!(entries.iter().any(|(p, t)| p == &link_path && t.is_symlink()));
+    assert!(entries
+        .iter()
+        .any(|(p, t)| p == &root.join("dir") && t.is_dir()));
+    assert!(entries
+        .iter()
+        .any(|(p, t)| p == &root.join("dir/file.txt") && t.is_file()));
+    assert!(entries
+        .iter()
+        .any(|(p, t)| p == &root.join("top.txt") && t.is_file()));
+    assert!(entries
+        .iter()
+        .any(|(p, t)| p == &link_path && t.is_symlink()));
 }


### PR DESCRIPTION
## Summary
- return `Result` entries from `walk` and preserve traversal errors
- handle potential traversal failures in `engine::sync`
- adjust walk tests for new `Result` iterator

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68b02413fcd0832398012203f5cec4fc