### PR TITLE
Replace anyhow errors with EngineError

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,12 +77,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.99"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
-
-[[package]]
 name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -238,7 +232,6 @@ checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 name = "cli"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "clap",
  "engine",
  "protocol",
@@ -318,9 +311,9 @@ checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 name = "engine"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "checksums",
  "tempfile",
+ "thiserror",
  "walk",
 ]
 
@@ -682,7 +675,6 @@ checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 name = "rsync-rs"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "assert_cmd",
  "checksums",
  "cli",
@@ -696,8 +688,8 @@ dependencies = [
 name = "rsync-rs-bin"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "cli",
+ "engine",
 ]
 
 [[package]]
@@ -794,6 +786,26 @@ name = "termtree"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "transport"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ edition = "2021"
 [dependencies]
 protocol = { path = "crates/protocol" }
 checksums = { path = "crates/checksums" }
-anyhow = "1"
 cli = { path = "crates/cli" }
 engine = { path = "crates/engine" }
 

--- a/bin/rsync-rs/Cargo.toml
+++ b/bin/rsync-rs/Cargo.toml
@@ -8,5 +8,5 @@ name = "rsync-rs"
 path = "src/main.rs"
 
 [dependencies]
-anyhow = "1"
 cli = { path = "../../crates/cli" }
+engine = { path = "../../crates/engine" }

--- a/bin/rsync-rs/src/main.rs
+++ b/bin/rsync-rs/src/main.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use engine::Result;
 
 fn main() -> Result<()> {
     cli::run()

--- a/crates/checksums/src/lib.rs
+++ b/crates/checksums/src/lib.rs
@@ -2,6 +2,19 @@ use md5::{Digest, Md5};
 use sha1::Sha1;
 #[cfg(feature = "blake3")]
 use blake3::Hasher as Blake3;
+use std::fmt;
+
+/// Error type for checksum operations.
+#[derive(Debug)]
+pub struct ChecksumError(pub String);
+
+impl fmt::Display for ChecksumError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl std::error::Error for ChecksumError {}
 
 /// Algorithms that can be used for the strong digest.
 #[derive(Clone, Copy, Debug)]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-anyhow = "1"
 clap = { version = "4", features = ["derive"] }
 engine = { path = "../engine" }
 protocol = { path = "../protocol" }

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-anyhow = "1"
+thiserror = "1"
 checksums = { path = "../checksums" }
 walk = { path = "../walk" }
 

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -3,8 +3,22 @@ use std::fs::{self, File};
 use std::io::{BufReader, BufWriter, Cursor, Read, Seek, SeekFrom, Write};
 use std::path::Path;
 
-use anyhow::Result;
-use checksums::{ChecksumConfig, ChecksumConfigBuilder};
+use checksums::{ChecksumConfig, ChecksumConfigBuilder, ChecksumError};
+use thiserror::Error;
+
+/// Error type for engine operations.
+#[derive(Debug, Error)]
+pub enum EngineError {
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+    #[error(transparent)]
+    Checksum(#[from] ChecksumError),
+    #[error("{0}")]
+    Other(String),
+}
+
+/// Result type for engine operations.
+pub type Result<T> = std::result::Result<T, EngineError>;
 use walk::walk;
 
 trait ReadSeek: Read + Seek {}

--- a/src/bin/rsync-rs.rs
+++ b/src/bin/rsync-rs.rs
@@ -1,3 +1,3 @@
-fn main() -> anyhow::Result<()> {
+fn main() -> engine::Result<()> {
     cli::run()
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
 use std::path::Path;
-
-use anyhow::Result;
+use engine::Result;
 
 /// Re-export engine synchronization for convenience.
 pub fn synchronize(src: &Path, dst: &Path) -> Result<()> {


### PR DESCRIPTION
## Summary
- define `EngineError` with IO and checksum variants
- switch codebase to `Result<T, EngineError>`
- update CLI and binaries to propagate `EngineError`

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68b02437a9288323aae672d62c33f5cc