### PR TITLE
Expose filters API at crate root

### DIFF
--- a/crates/filters/src/lib.rs
+++ b/crates/filters/src/lib.rs
@@ -1,104 +1,102 @@
-pub mod filters {
-    use globset::{Glob, GlobMatcher};
-    use std::path::Path;
+use globset::{Glob, GlobMatcher};
+use std::path::Path;
 
-    /// A single include or exclude rule compiled into a glob matcher.
-    #[derive(Clone)]
-    pub enum Rule {
-        Include(GlobMatcher),
-        Exclude(GlobMatcher),
+/// A single include or exclude rule compiled into a glob matcher.
+#[derive(Clone)]
+pub enum Rule {
+    Include(GlobMatcher),
+    Exclude(GlobMatcher),
+}
+
+impl Rule {
+    fn matches<P: AsRef<Path>>(&self, path: P) -> bool {
+        match self {
+            Rule::Include(m) | Rule::Exclude(m) => m.is_match(path),
+        }
     }
 
-    impl Rule {
-        fn matches<P: AsRef<Path>>(&self, path: P) -> bool {
-            match self {
-                Rule::Include(m) | Rule::Exclude(m) => m.is_match(path),
+    fn is_include(&self) -> bool {
+        matches!(self, Rule::Include(_))
+    }
+}
+
+/// Matcher evaluates rules sequentially against paths.
+#[derive(Clone, Default)]
+pub struct Matcher {
+    rules: Vec<Rule>,
+}
+
+impl Matcher {
+    pub fn new(rules: Vec<Rule>) -> Self {
+        Self { rules }
+    }
+
+    /// Determine if the provided path is included by the rules.
+    pub fn is_included<P: AsRef<Path>>(&self, path: P) -> bool {
+        let path = path.as_ref();
+        for rule in &self.rules {
+            if rule.matches(path) {
+                return rule.is_include();
             }
         }
+        true
+    }
 
-        fn is_include(&self) -> bool {
-            matches!(self, Rule::Include(_))
+    /// Merge additional rules, as when reading a per-directory `.rsync-filter`.
+    pub fn merge(&mut self, more: Vec<Rule>) {
+        self.rules.extend(more);
+    }
+}
+
+#[derive(Debug)]
+pub enum ParseError {
+    InvalidRule(String),
+    Glob(globset::Error),
+}
+
+impl From<globset::Error> for ParseError {
+    fn from(e: globset::Error) -> Self {
+        Self::Glob(e)
+    }
+}
+
+enum RuleKind {
+    Include,
+    Exclude,
+}
+
+/// Parse filter rules from input.
+pub fn parse(input: &str) -> Result<Vec<Rule>, ParseError> {
+    let mut rules = Vec::new();
+
+    for raw_line in input.lines() {
+        let line = raw_line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+
+        // Determine rule type based on the first character. Using
+        // `strip_prefix` keeps the logic simple and avoids manual
+        // character indexing.
+        let (kind, pattern) = if let Some(rest) = line.strip_prefix('+') {
+            (RuleKind::Include, rest.trim_start())
+        } else if let Some(rest) = line.strip_prefix('-') {
+            (RuleKind::Exclude, rest.trim_start())
+        } else {
+            return Err(ParseError::InvalidRule(raw_line.to_string()));
+        };
+
+        if pattern.is_empty() {
+            return Err(ParseError::InvalidRule(raw_line.to_string()));
+        }
+
+        let matcher = Glob::new(pattern)?.compile_matcher();
+
+        match kind {
+            RuleKind::Include => rules.push(Rule::Include(matcher)),
+            RuleKind::Exclude => rules.push(Rule::Exclude(matcher)),
         }
     }
 
-    /// Matcher evaluates rules sequentially against paths.
-    #[derive(Clone, Default)]
-    pub struct Matcher {
-        rules: Vec<Rule>,
-    }
-
-    impl Matcher {
-        pub fn new(rules: Vec<Rule>) -> Self {
-            Self { rules }
-        }
-
-        /// Determine if the provided path is included by the rules.
-        pub fn is_included<P: AsRef<Path>>(&self, path: P) -> bool {
-            let path = path.as_ref();
-            for rule in &self.rules {
-                if rule.matches(path) {
-                    return rule.is_include();
-                }
-            }
-            true
-        }
-
-        /// Merge additional rules, as when reading a per-directory `.rsync-filter`.
-        pub fn merge(&mut self, more: Vec<Rule>) {
-            self.rules.extend(more);
-        }
-    }
-
-    #[derive(Debug)]
-    pub enum ParseError {
-        InvalidRule(String),
-        Glob(globset::Error),
-    }
-
-    impl From<globset::Error> for ParseError {
-        fn from(e: globset::Error) -> Self {
-            Self::Glob(e)
-        }
-    }
-
-    enum RuleKind {
-        Include,
-        Exclude,
-    }
-
-    /// Parse filter rules from input.
-    pub fn parse(input: &str) -> Result<Vec<Rule>, ParseError> {
-        let mut rules = Vec::new();
-
-        for raw_line in input.lines() {
-            let line = raw_line.trim();
-            if line.is_empty() || line.starts_with('#') {
-                continue;
-            }
-
-            // Determine rule type based on the first character. Using
-            // `strip_prefix` keeps the logic simple and avoids manual
-            // character indexing.
-            let (kind, pattern) = if let Some(rest) = line.strip_prefix('+') {
-                (RuleKind::Include, rest.trim_start())
-            } else if let Some(rest) = line.strip_prefix('-') {
-                (RuleKind::Exclude, rest.trim_start())
-            } else {
-                return Err(ParseError::InvalidRule(raw_line.to_string()));
-            };
-
-            if pattern.is_empty() {
-                return Err(ParseError::InvalidRule(raw_line.to_string()));
-            }
-
-            let matcher = Glob::new(pattern)?.compile_matcher();
-
-            match kind {
-                RuleKind::Include => rules.push(Rule::Include(matcher)),
-                RuleKind::Exclude => rules.push(Rule::Exclude(matcher)),
-            }
-        }
-
-        Ok(rules)
-    }
+    Ok(rules)
 }

--- a/crates/filters/tests/comments.rs
+++ b/crates/filters/tests/comments.rs
@@ -1,4 +1,4 @@
-use filters::filters::{parse, Matcher};
+use filters::{parse, Matcher};
 
 #[test]
 fn comments_and_blank_lines_are_ignored() {

--- a/crates/filters/tests/include_exclude.rs
+++ b/crates/filters/tests/include_exclude.rs
@@ -1,4 +1,4 @@
-use filters::filters::{parse, Matcher};
+use filters::{parse, Matcher};
 
 #[test]
 fn include_and_exclude() {

--- a/crates/filters/tests/merge.rs
+++ b/crates/filters/tests/merge.rs
@@ -1,4 +1,4 @@
-use filters::filters::{parse, Matcher};
+use filters::{parse, Matcher};
 
 #[test]
 fn rsync_filter_merge() {

--- a/crates/fuzz/fuzz_targets/filters_parse_fuzz.rs
+++ b/crates/fuzz/fuzz_targets/filters_parse_fuzz.rs
@@ -1,5 +1,4 @@
 #![no_main]
-use filters::filters;
 use fuzz::helpers;
 use libfuzzer_sys::fuzz_target;
 


### PR DESCRIPTION
## Summary
- expose `Rule`, `Matcher`, `ParseError`, and `parse` directly from the `filters` crate
- update tests and fuzz target to import from the crate root

## Testing
- `cargo test` *(fails: `EngineError` missing `From<walkdir::error::Error>`)*
- `cargo test -p filters`


------
https://chatgpt.com/codex/tasks/task_e_68b026e1c3a08323849f2eed7bf474b6