### PR TITLE
Improve remote spec parsing with IPv6 and Windows paths

### DIFF
--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -49,11 +49,25 @@ fn remote_destination_syncs() {
     let dst_spec = format!("remote:{}", dst_dir.to_str().unwrap());
 
     let mut cmd = Command::cargo_bin("rsync-rs").unwrap();
-    cmd.args([
-        "client",
-        src_dir.to_str().unwrap(),
-        &dst_spec,
-    ]);
+    cmd.args(["client", src_dir.to_str().unwrap(), &dst_spec]);
+    cmd.assert().success();
+
+    let out = std::fs::read(dst_dir.join("file.txt")).unwrap();
+    assert_eq!(out, b"hello");
+}
+
+#[test]
+fn remote_destination_ipv6_syncs() {
+    let dir = tempdir().unwrap();
+    let src_dir = dir.path().join("src");
+    let dst_dir = dir.path().join("remote_dst_v6");
+    std::fs::create_dir_all(&src_dir).unwrap();
+    std::fs::write(src_dir.join("file.txt"), b"hello").unwrap();
+
+    let dst_spec = format!("[::1]:{}", dst_dir.to_str().unwrap());
+
+    let mut cmd = Command::cargo_bin("rsync-rs").unwrap();
+    cmd.args(["client", src_dir.to_str().unwrap(), &dst_spec]);
     cmd.assert().success();
 
     let out = std::fs::read(dst_dir.join("file.txt")).unwrap();


### PR DESCRIPTION
## Summary
- add `RemoteSpec` enum and `parse_remote_spec` helper
- update client logic to use structured remote specs
- test IPv6 remote specs and Windows path handling

## Testing
- `cargo test` *(fails: `EngineError` missing `From<walkdir::error::Error>`)*

------
https://chatgpt.com/codex/tasks/task_e_68b027e47ebc83239eabe7a19a47182c