### PR TITLE
feat(cli): support remote pairings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -235,6 +235,7 @@ dependencies = [
  "clap",
  "engine",
  "protocol",
+ "transport",
 ]
 
 [[package]]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2021"
 clap = { version = "4", features = ["derive"] }
 engine = { path = "../engine" }
 protocol = { path = "../protocol" }
+transport = { path = "../transport" }

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -1,11 +1,12 @@
 use std::env;
-use std::io::{Read, Write};
+use std::io::{self, Read, Write};
 use std::net::TcpStream;
 use std::path::PathBuf;
 
 use clap::{Parser, Subcommand};
 use engine::{sync, EngineError, Result};
 use protocol::{negotiate_version, LATEST_VERSION};
+use transport::{SshStdioTransport, Transport};
 
 /// Command line interface for rsync-rs.
 #[derive(Parser)]
@@ -128,6 +129,22 @@ fn parse_remote_spec(s: &str) -> Result<RemoteSpec> {
     Ok(RemoteSpec::Local(PathBuf::from(s)))
 }
 
+fn pipe_transports<S, D>(mut src: S, mut dst: D) -> io::Result<()>
+where
+    S: Transport,
+    D: Transport,
+{
+    let mut buf = [0u8; 8192];
+    loop {
+        let n = src.receive(&mut buf)?;
+        if n == 0 {
+            break;
+        }
+        dst.send(&buf[..n])?;
+    }
+    Ok(())
+}
+
 fn run_client(opts: ClientOpts) -> Result<()> {
     let src = parse_remote_spec(&opts.src)?;
     let dst = parse_remote_spec(&opts.dst)?;
@@ -152,9 +169,38 @@ fn run_client(opts: ClientOpts) -> Result<()> {
                 sync(&src, &dst)?;
                 Ok(())
             }
-            (RemoteSpec::Remote { .. }, RemoteSpec::Remote { .. }) => Err(EngineError::Other(
-                "remote to remote sync not implemented".into(),
-            )),
+            (
+                RemoteSpec::Remote {
+                    host: src_host,
+                    path: src_path,
+                },
+                RemoteSpec::Remote {
+                    host: dst_host,
+                    path: dst_path,
+                },
+            ) => {
+                if src_host.is_empty() || dst_host.is_empty() {
+                    return Err(EngineError::Other(
+                        "remote host missing".to_string(),
+                    ));
+                }
+                if src_path.as_os_str().is_empty() || dst_path.as_os_str().is_empty() {
+                    return Err(EngineError::Other(
+                        "remote path missing".to_string(),
+                    ));
+                }
+
+                let src_session =
+                    SshStdioTransport::spawn(&src_host, [src_path.as_os_str()])
+                        .map_err(|e| EngineError::Other(e.to_string()))?;
+                let dst_session =
+                    SshStdioTransport::spawn(&dst_host, [dst_path.as_os_str()])
+                        .map_err(|e| EngineError::Other(e.to_string()))?;
+
+                pipe_transports(src_session, dst_session)
+                    .map_err(|e| EngineError::Other(e.to_string()))?;
+                Ok(())
+            }
         }
     }
 }

--- a/tests/remote_remote.rs
+++ b/tests/remote_remote.rs
@@ -1,0 +1,43 @@
+use assert_cmd::Command;
+use tempfile::tempdir;
+use std::fs;
+
+#[test]
+fn remote_to_remote_pipes_data() {
+    let dir = tempdir().unwrap();
+    let src_file = dir.path().join("src.txt");
+    let dst_file = dir.path().join("dst.txt");
+    fs::write(&src_file, b"hello remote\n").unwrap();
+
+    let src_script = dir.path().join("src.sh");
+    fs::write(&src_script, format!("#!/bin/sh\ncat {}\n", src_file.display())).unwrap();
+
+    let dst_script = dir.path().join("dst.sh");
+    fs::write(&dst_script, format!("#!/bin/sh\ncat > {}\n", dst_file.display())).unwrap();
+
+    let src_spec = format!("sh:{}", src_script.to_str().unwrap());
+    let dst_spec = format!("sh:{}", dst_script.to_str().unwrap());
+
+    let mut cmd = Command::cargo_bin("rsync-rs").unwrap();
+    cmd.args(["client", &src_spec, &dst_spec]);
+    cmd.assert().success();
+
+    let out = fs::read(&dst_file).unwrap();
+    assert_eq!(out, b"hello remote\n");
+}
+
+#[test]
+fn remote_pair_missing_host_fails() {
+    let mut cmd = Command::cargo_bin("rsync-rs").unwrap();
+    // Missing host in source spec should yield an error before attempting connections
+    cmd.args(["client", ":/tmp/src", "sh:/tmp/dst"]);
+    cmd.assert().failure();
+}
+
+#[test]
+fn remote_pair_missing_path_fails() {
+    let mut cmd = Command::cargo_bin("rsync-rs").unwrap();
+    // Missing path in source spec should also fail
+    cmd.args(["client", "sh:", "sh:/tmp/dst"]);
+    cmd.assert().failure();
+}


### PR DESCRIPTION
## Summary
- extend client to bridge remote to remote paths
- validate remote host and path arguments
- test remote pairings and invalid specs

## Testing
- `cargo test -q`

------
https://chatgpt.com/codex/tasks/task_e_68b02e7c884083239fe667e3a74e6423