### PR TITLE
Add CLI flags for common rsync options

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -36,7 +36,7 @@ rsync-rs [OPTIONS] <SRC> <DEST>
 - `-n, --dry-run` – perform a trial run with no changes made.
 - `-v, --verbose` – increase logging verbosity.
 - `--delete` – remove extraneous files from the destination.
-- `--checksum` – use full checksums to determine file changes.
+- `-c, --checksum` – use full checksums to determine file changes.
 - `--stats` – display transfer statistics on completion.
 - `--config <FILE>` – supply a custom configuration file.
 


### PR DESCRIPTION
## Summary
- support standard rsync flags (recursive, dry-run, verbose, delete, checksum, stats, config) in the client CLI
- handle new flags in client execution with placeholder behaviour
- document new options and add argument parsing tests

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68b030d3a4a483239905f1088aa4aa0a