### PR TITLE
refactor: flatten cli flags

### DIFF
--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -11,7 +11,6 @@ fn client_local_sync() {
 
     let mut cmd = Command::cargo_bin("rsync-rs").unwrap();
     cmd.args([
-        "client",
         "--local",
         src_dir.to_str().unwrap(),
         dst_dir.to_str().unwrap(),
@@ -30,11 +29,7 @@ fn local_sync_without_flag_fails() {
     std::fs::create_dir_all(&src_dir).unwrap();
 
     let mut cmd = Command::cargo_bin("rsync-rs").unwrap();
-    cmd.args([
-        "client",
-        src_dir.to_str().unwrap(),
-        dst_dir.to_str().unwrap(),
-    ]);
+    cmd.args([src_dir.to_str().unwrap(), dst_dir.to_str().unwrap()]);
     cmd.assert().failure();
 }
 
@@ -49,7 +44,7 @@ fn remote_destination_syncs() {
     let dst_spec = format!("remote:{}", dst_dir.to_str().unwrap());
 
     let mut cmd = Command::cargo_bin("rsync-rs").unwrap();
-    cmd.args(["client", src_dir.to_str().unwrap(), &dst_spec]);
+    cmd.args([src_dir.to_str().unwrap(), &dst_spec]);
     cmd.assert().success();
 
     let out = std::fs::read(dst_dir.join("file.txt")).unwrap();
@@ -67,7 +62,7 @@ fn remote_destination_ipv6_syncs() {
     let dst_spec = format!("[::1]:{}", dst_dir.to_str().unwrap());
 
     let mut cmd = Command::cargo_bin("rsync-rs").unwrap();
-    cmd.args(["client", src_dir.to_str().unwrap(), &dst_spec]);
+    cmd.args([src_dir.to_str().unwrap(), &dst_spec]);
     cmd.assert().success();
 
     let out = std::fs::read(dst_dir.join("file.txt")).unwrap();

--- a/tests/daemon.rs
+++ b/tests/daemon.rs
@@ -1,17 +1,17 @@
 use assert_cmd::prelude::*;
 use assert_cmd::Command;
 use protocol::LATEST_VERSION;
+use serial_test::serial;
 use std::io::{Read, Write};
 use std::net::TcpStream;
 use std::process::{Child, Command as StdCommand};
 use std::thread::sleep;
 use std::time::Duration;
-use serial_test::serial;
 
 fn spawn_daemon() -> Child {
     StdCommand::cargo_bin("rsync-rs")
         .unwrap()
-        .args(["daemon", "--module", "data=/tmp"])
+        .args(["--daemon", "--module", "data=/tmp"])
         .spawn()
         .unwrap()
 }
@@ -32,9 +32,7 @@ fn daemon_negotiates_version_with_client() {
     let mut child = spawn_daemon();
     wait_for_daemon();
     let mut stream = TcpStream::connect("127.0.0.1:873").unwrap();
-    stream
-        .write_all(&LATEST_VERSION.to_be_bytes())
-        .unwrap();
+    stream.write_all(&LATEST_VERSION.to_be_bytes()).unwrap();
     let mut buf = [0u8; 4];
     stream.read_exact(&mut buf).unwrap();
     assert_eq!(u32::from_be_bytes(buf), LATEST_VERSION);
@@ -49,7 +47,7 @@ fn probe_connects_to_daemon() {
     wait_for_daemon();
     Command::cargo_bin("rsync-rs")
         .unwrap()
-        .args(["probe", "127.0.0.1:873"])
+        .args(["--probe", "127.0.0.1:873"])
         .assert()
         .success();
     let _ = child.kill();
@@ -61,8 +59,7 @@ fn probe_connects_to_daemon() {
 fn probe_rejects_old_version() {
     Command::cargo_bin("rsync-rs")
         .unwrap()
-        .args(["probe", "--peer-version", "1"])
+        .args(["--probe", "--peer-version", "1"])
         .assert()
         .failure();
 }
-

--- a/tests/local_sync_tree.rs
+++ b/tests/local_sync_tree.rs
@@ -33,12 +33,7 @@ fn sync_directory_tree() {
 
     Command::cargo_bin("rsync-rs")
         .unwrap()
-        .args([
-            "client",
-            "--local",
-            src.to_str().unwrap(),
-            dst.to_str().unwrap(),
-        ])
+        .args(["--local", src.to_str().unwrap(), dst.to_str().unwrap()])
         .assert()
         .success()
         .stdout("")

--- a/tests/remote_remote.rs
+++ b/tests/remote_remote.rs
@@ -1,6 +1,6 @@
 use assert_cmd::Command;
-use tempfile::tempdir;
 use std::fs;
+use tempfile::tempdir;
 
 #[test]
 fn remote_to_remote_pipes_data() {
@@ -10,16 +10,24 @@ fn remote_to_remote_pipes_data() {
     fs::write(&src_file, b"hello remote\n").unwrap();
 
     let src_script = dir.path().join("src.sh");
-    fs::write(&src_script, format!("#!/bin/sh\ncat {}\n", src_file.display())).unwrap();
+    fs::write(
+        &src_script,
+        format!("#!/bin/sh\ncat {}\n", src_file.display()),
+    )
+    .unwrap();
 
     let dst_script = dir.path().join("dst.sh");
-    fs::write(&dst_script, format!("#!/bin/sh\ncat > {}\n", dst_file.display())).unwrap();
+    fs::write(
+        &dst_script,
+        format!("#!/bin/sh\ncat > {}\n", dst_file.display()),
+    )
+    .unwrap();
 
     let src_spec = format!("sh:{}", src_script.to_str().unwrap());
     let dst_spec = format!("sh:{}", dst_script.to_str().unwrap());
 
     let mut cmd = Command::cargo_bin("rsync-rs").unwrap();
-    cmd.args(["client", &src_spec, &dst_spec]);
+    cmd.args([&src_spec, &dst_spec]);
     cmd.assert().success();
 
     let out = fs::read(&dst_file).unwrap();
@@ -30,7 +38,7 @@ fn remote_to_remote_pipes_data() {
 fn remote_pair_missing_host_fails() {
     let mut cmd = Command::cargo_bin("rsync-rs").unwrap();
     // Missing host in source spec should yield an error before attempting connections
-    cmd.args(["client", ":/tmp/src", "sh:/tmp/dst"]);
+    cmd.args([":/tmp/src", "sh:/tmp/dst"]);
     cmd.assert().failure();
 }
 
@@ -38,6 +46,6 @@ fn remote_pair_missing_host_fails() {
 fn remote_pair_missing_path_fails() {
     let mut cmd = Command::cargo_bin("rsync-rs").unwrap();
     // Missing path in source spec should also fail
-    cmd.args(["client", "sh:", "sh:/tmp/dst"]);
+    cmd.args(["sh:", "sh:/tmp/dst"]);
     cmd.assert().failure();
 }


### PR DESCRIPTION
## Summary
- refactor cli parsing to use flags instead of subcommands
- map common rsync flags including `-z` compression
- support positional SRC and DST arguments and update tests

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b035db27d88323ae90e075c58f80d1