### PR TITLE
Support per-directory .rsync-filter files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -374,6 +374,7 @@ name = "filters"
 version = "0.1.0"
 dependencies = [
  "globset",
+ "tempfile",
 ]
 
 [[package]]

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -233,6 +233,9 @@ impl Receiver {
 
 /// Synchronize the contents of directory `src` into `dst`.
 pub fn sync(src: &Path, dst: &Path, matcher: &Matcher) -> Result<()> {
+    // Clone the matcher and attach the source root so per-directory filter files
+    // can be located during the walk.
+    let matcher = matcher.clone().with_root(src.to_path_buf());
     let mut sender = Sender::new(1024, matcher.clone());
     let mut receiver = Receiver::new();
     sender.start();

--- a/crates/filters/Cargo.toml
+++ b/crates/filters/Cargo.toml
@@ -5,3 +5,6 @@ edition = "2021"
 
 [dependencies]
 globset = "0.4"
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/filters/src/lib.rs
+++ b/crates/filters/src/lib.rs
@@ -1,5 +1,8 @@
 use globset::{Glob, GlobMatcher};
-use std::path::Path;
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
 
 /// A single include or exclude rule compiled into a glob matcher.
 #[derive(Clone)]
@@ -23,18 +26,56 @@ impl Rule {
 /// Matcher evaluates rules sequentially against paths.
 #[derive(Clone, Default)]
 pub struct Matcher {
+    /// Root of the walk. Used to locate `.rsync-filter` files.
+    root: Option<PathBuf>,
+    /// Global rules supplied via CLI or configuration.
     rules: Vec<Rule>,
+    /// Cache of parsed rules for directories already visited.
+    cached: RefCell<HashMap<PathBuf, Vec<Rule>>>,
 }
 
 impl Matcher {
     pub fn new(rules: Vec<Rule>) -> Self {
-        Self { rules }
+        Self {
+            root: None,
+            rules,
+            cached: RefCell::new(HashMap::new()),
+        }
     }
 
-    /// Determine if the provided path is included by the rules.
+    /// Set the root directory used to resolve per-directory filter files.
+    pub fn with_root(mut self, root: impl Into<PathBuf>) -> Self {
+        self.root = Some(root.into());
+        self
+    }
+
+    /// Determine if the provided path is included by the rules, loading any
+    /// directory-specific `.rsync-filter` files along the way. Rules discovered
+    /// later in the walk take precedence over earlier ones, mirroring rsync's
+    /// evaluation order.
     pub fn is_included<P: AsRef<Path>>(&self, path: P) -> bool {
         let path = path.as_ref();
-        for rule in &self.rules {
+        let mut active = Vec::new();
+
+        if let Some(root) = &self.root {
+            let mut dirs = Vec::new();
+            let mut dir = root.clone();
+            dirs.push(dir.clone());
+            if let Some(parent) = path.parent() {
+                for comp in parent.components() {
+                    dir.push(comp.as_os_str());
+                    dirs.push(dir.clone());
+                }
+            }
+            for d in dirs.iter().rev() {
+                active.extend(self.dir_rules(d));
+            }
+        }
+
+        // Global rules have the lowest precedence.
+        active.extend(self.rules.clone());
+
+        for rule in &active {
             if rule.matches(path) {
                 return rule.is_include();
             }
@@ -42,9 +83,60 @@ impl Matcher {
         true
     }
 
-    /// Merge additional rules, as when reading a per-directory `.rsync-filter`.
+    /// Merge additional global rules, as when reading a top-level filter file.
     pub fn merge(&mut self, more: Vec<Rule>) {
         self.rules.extend(more);
+    }
+
+    /// Load cached rules for `dir`, reading its `.rsync-filter` file if needed.
+    fn dir_rules(&self, dir: &Path) -> Vec<Rule> {
+        let mut cache = self.cached.borrow_mut();
+        if let Some(r) = cache.get(dir) {
+            return r.clone();
+        }
+        let file = dir.join(".rsync-filter");
+        let rules = match fs::read_to_string(&file) {
+            Ok(content) => {
+                let rel = self
+                    .root
+                    .as_ref()
+                    .and_then(|r| dir.strip_prefix(r).ok())
+                    .filter(|p| !p.as_os_str().is_empty());
+                let adjusted = if let Some(rel) = rel {
+                    let mut buf = String::new();
+                    let rel_str = rel.to_string_lossy();
+                    for raw_line in content.lines() {
+                        let line = raw_line.trim();
+                        if line.is_empty() || line.starts_with('#') {
+                            continue;
+                        }
+                        let (kind, pat) = if let Some(rest) = line.strip_prefix('+') {
+                            ('+', rest.trim_start())
+                        } else if let Some(rest) = line.strip_prefix('-') {
+                            ('-', rest.trim_start())
+                        } else {
+                            continue;
+                        };
+                        let new_pat = if pat.contains('/') {
+                            format!("{}/{}", rel_str, pat)
+                        } else {
+                            format!("{}/**/{}", rel_str, pat)
+                        };
+                        buf.push(kind);
+                        buf.push(' ');
+                        buf.push_str(&new_pat);
+                        buf.push('\n');
+                    }
+                    buf
+                } else {
+                    content
+                };
+                parse(&adjusted).unwrap_or_default()
+            }
+            Err(_) => Vec::new(),
+        };
+        cache.insert(dir.to_path_buf(), rules.clone());
+        rules
     }
 }
 
@@ -90,7 +182,13 @@ pub fn parse(input: &str) -> Result<Vec<Rule>, ParseError> {
             return Err(ParseError::InvalidRule(raw_line.to_string()));
         }
 
-        let matcher = Glob::new(pattern)?.compile_matcher();
+        let pat = if pattern.contains('/') {
+            pattern.to_string()
+        } else {
+            format!("**/{}", pattern)
+        };
+
+        let matcher = Glob::new(&pat)?.compile_matcher();
 
         match kind {
             RuleKind::Include => rules.push(Rule::Include(matcher)),

--- a/crates/filters/tests/rsync_filter_files.rs
+++ b/crates/filters/tests/rsync_filter_files.rs
@@ -1,0 +1,37 @@
+use filters::Matcher;
+use std::fs;
+use tempfile::tempdir;
+
+#[test]
+fn include_overrides_parent_exclude() {
+    let tmp = tempdir().unwrap();
+    let root = tmp.path();
+    fs::write(root.join(".rsync-filter"), "- *.tmp\n").unwrap();
+    let sub = root.join("sub");
+    fs::create_dir_all(&sub).unwrap();
+    fs::write(sub.join(".rsync-filter"), "+ keep.tmp\n").unwrap();
+
+    let matcher = Matcher::new(Vec::new()).with_root(root);
+
+    assert!(!matcher.is_included("other.tmp"));
+    assert!(matcher.is_included("sub/keep.tmp"));
+    assert!(!matcher.is_included("sub/other.tmp"));
+}
+
+#[test]
+fn nested_filters_apply_in_order() {
+    let tmp = tempdir().unwrap();
+    let root = tmp.path();
+    fs::write(root.join(".rsync-filter"), "- *.log\n").unwrap();
+    let dir = root.join("dir");
+    let sub = dir.join("sub");
+    fs::create_dir_all(&sub).unwrap();
+    fs::write(dir.join(".rsync-filter"), "+ debug.log\n").unwrap();
+    fs::write(sub.join(".rsync-filter"), "- debug.log\n").unwrap();
+
+    let matcher = Matcher::new(Vec::new()).with_root(root);
+
+    assert!(matcher.is_included("dir/debug.log"));
+    assert!(!matcher.is_included("dir/sub/debug.log"));
+    assert!(!matcher.is_included("dir/info.log"));
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -47,3 +47,26 @@ rsync-rs [OPTIONS] <SRC> <DEST>
 3. Configuration file (defaults to `~/.config/rsync-rs/config.toml`)
 
 Settings specified earlier in the list override later sources.
+
+## Filters
+
+`rsync-rs` supports include and exclude rules using the same syntax as
+`rsync`. Rules can be supplied on the command line with `--filter` or placed in
+`.rsync-filter` files located throughout the source tree. When walking
+directories the tool automatically loads any `.rsync-filter` files and merges
+their rules with those from parent directories. Rules in deeper directories take
+precedence over rules defined higher up.
+
+### Example
+
+```
+project/
+├── .rsync-filter      # contains: - *.tmp
+└── logs/
+    ├── .rsync-filter  # contains: + keep.tmp
+    ├── keep.tmp
+    └── other.tmp
+```
+
+In this layout, `keep.tmp` is included because the rule in `logs/.rsync-filter`
+overrides the root exclusion. The file `other.tmp` remains excluded.


### PR DESCRIPTION
## Summary
- load `.rsync-filter` files during walks and merge them with higher precedence for deeper directories
- hook engine to set matcher root so directory-specific filters are discovered
- document filter behavior and precedence
- test nested include/exclude overrides and pattern loading

## Testing
- `cargo test -p filters`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68b038efbe5083239185daf7a5f9e5e9