### PR TITLE
Wire rsync core options through CLI and engine

### DIFF
--- a/crates/engine/tests/compress.rs
+++ b/crates/engine/tests/compress.rs
@@ -1,7 +1,7 @@
 use std::fs;
 
 use compress::Codec;
-use engine::sync;
+use engine::{sync, SyncOptions};
 use filters::Matcher;
 use tempfile::tempdir;
 
@@ -12,7 +12,14 @@ fn zlib_roundtrip() {
     let dst = tmp.path().join("dst");
     fs::create_dir_all(&src).unwrap();
     fs::write(src.join("file.txt"), b"hello world").unwrap();
-    sync(&src, &dst, &Matcher::default(), &[Codec::Zlib]).unwrap();
+    sync(
+        &src,
+        &dst,
+        &Matcher::default(),
+        &[Codec::Zlib],
+        &SyncOptions { compress: true, ..Default::default() },
+    )
+    .unwrap();
     assert_eq!(fs::read(dst.join("file.txt")).unwrap(), b"hello world");
 }
 
@@ -23,7 +30,14 @@ fn zstd_roundtrip() {
     let dst = tmp.path().join("dst");
     fs::create_dir_all(&src).unwrap();
     fs::write(src.join("file.txt"), b"hello world").unwrap();
-    sync(&src, &dst, &Matcher::default(), &[Codec::Zstd]).unwrap();
+    sync(
+        &src,
+        &dst,
+        &Matcher::default(),
+        &[Codec::Zstd],
+        &SyncOptions { compress: true, ..Default::default() },
+    )
+    .unwrap();
     assert_eq!(fs::read(dst.join("file.txt")).unwrap(), b"hello world");
 }
 
@@ -34,6 +48,13 @@ fn lz4_roundtrip() {
     let dst = tmp.path().join("dst");
     fs::create_dir_all(&src).unwrap();
     fs::write(src.join("file.txt"), b"hello world").unwrap();
-    sync(&src, &dst, &Matcher::default(), &[Codec::Lz4]).unwrap();
+    sync(
+        &src,
+        &dst,
+        &Matcher::default(),
+        &[Codec::Lz4],
+        &SyncOptions { compress: true, ..Default::default() },
+    )
+    .unwrap();
     assert_eq!(fs::read(dst.join("file.txt")).unwrap(), b"hello world");
 }

--- a/crates/engine/tests/filter.rs
+++ b/crates/engine/tests/filter.rs
@@ -1,5 +1,5 @@
 use compress::available_codecs;
-use engine::sync;
+use engine::{sync, SyncOptions};
 use filters::{parse, Matcher};
 use std::fs;
 use tempfile::tempdir;
@@ -16,7 +16,14 @@ fn excluded_paths_are_skipped() {
     let rules = parse("- skip.txt").unwrap();
     let matcher = Matcher::new(rules);
 
-    sync(&src, &dst, &matcher, available_codecs()).unwrap();
+    sync(
+        &src,
+        &dst,
+        &matcher,
+        available_codecs(),
+        &SyncOptions::default(),
+    )
+    .unwrap();
 
     assert!(dst.join("include.txt").exists());
     assert!(!dst.join("skip.txt").exists());

--- a/crates/engine/tests/streaming.rs
+++ b/crates/engine/tests/streaming.rs
@@ -1,5 +1,5 @@
 use compress::available_codecs;
-use engine::sync;
+use engine::{sync, SyncOptions};
 use filters::Matcher;
 use std::fs;
 use tempfile::tempdir;
@@ -17,7 +17,14 @@ fn sync_large_file_streaming() {
     }
     fs::write(src.join("file.bin"), &data).unwrap();
 
-    sync(&src, &dst, &Matcher::default(), available_codecs()).unwrap();
+    sync(
+        &src,
+        &dst,
+        &Matcher::default(),
+        available_codecs(),
+        &SyncOptions::default(),
+    )
+    .unwrap();
     let out = fs::read(dst.join("file.bin")).unwrap();
     assert_eq!(out, data);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,18 @@
 use std::path::Path;
 use compress::available_codecs;
-use engine::Result;
+use engine::{Result, SyncOptions};
 use filters::Matcher;
 
 /// Re-export engine synchronization for convenience.
 pub fn synchronize(src: &Path, dst: &Path) -> Result<()> {
-    engine::sync(src, dst, &Matcher::default(), available_codecs())
+    engine::sync(
+        src,
+        dst,
+        &Matcher::default(),
+        available_codecs(),
+        &SyncOptions::default(),
+    )
+    .map(|_| ())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- add SyncOptions/Stats to engine with delete, checksum, compression control
- expose stats and flags via CLI
- enable optional compression and deletion semantics

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b04fdd26e88323965b592be276a019