### PR TITLE
Propagate filter parse errors

### DIFF
--- a/crates/filters/tests/comments.rs
+++ b/crates/filters/tests/comments.rs
@@ -6,6 +6,6 @@ fn comments_and_blank_lines_are_ignored() {
     let rules = parse("# initial comment\n\n+ keep.log\n- *.log\n").expect("parse");
     let matcher = Matcher::new(rules);
 
-    assert!(matcher.is_included("keep.log"));
-    assert!(!matcher.is_included("debug.log"));
+    assert!(matcher.is_included("keep.log").unwrap());
+    assert!(!matcher.is_included("debug.log").unwrap());
 }

--- a/crates/filters/tests/include_exclude.rs
+++ b/crates/filters/tests/include_exclude.rs
@@ -5,7 +5,7 @@ fn include_and_exclude() {
     let rules = parse("+ special.tmp\n- *.tmp\n").expect("parse");
     let matcher = Matcher::new(rules);
 
-    assert!(matcher.is_included("special.tmp"));
-    assert!(!matcher.is_included("other.tmp"));
-    assert!(matcher.is_included("notes.txt"));
+    assert!(matcher.is_included("special.tmp").unwrap());
+    assert!(!matcher.is_included("other.tmp").unwrap());
+    assert!(matcher.is_included("notes.txt").unwrap());
 }

--- a/crates/filters/tests/malformed.rs
+++ b/crates/filters/tests/malformed.rs
@@ -1,0 +1,12 @@
+use filters::Matcher;
+use std::fs;
+use tempfile::tempdir;
+
+#[test]
+fn malformed_filter_file_returns_error() {
+    let tmp = tempdir().unwrap();
+    let root = tmp.path();
+    fs::write(root.join(".rsync-filter"), "+\n").unwrap();
+    let matcher = Matcher::new(Vec::new()).with_root(root);
+    assert!(matcher.is_included("foo").is_err());
+}

--- a/crates/filters/tests/merge.rs
+++ b/crates/filters/tests/merge.rs
@@ -5,13 +5,13 @@ fn rsync_filter_merge() {
     let root_rules = parse("- *.tmp\n").unwrap();
     let mut matcher = Matcher::new(root_rules);
 
-    assert!(matcher.is_included("notes.txt"));
-    assert!(!matcher.is_included("junk.tmp"));
+    assert!(matcher.is_included("notes.txt").unwrap());
+    assert!(!matcher.is_included("junk.tmp").unwrap());
 
     // Merge rules from a subdirectory `.rsync-filter` file
     let sub_rules = parse("- secret\n").unwrap();
     matcher.merge(sub_rules);
 
-    assert!(!matcher.is_included("junk.tmp"));
-    assert!(!matcher.is_included("secret"));
+    assert!(!matcher.is_included("junk.tmp").unwrap());
+    assert!(!matcher.is_included("secret").unwrap());
 }

--- a/crates/filters/tests/rsync_filter_files.rs
+++ b/crates/filters/tests/rsync_filter_files.rs
@@ -13,9 +13,9 @@ fn include_overrides_parent_exclude() {
 
     let matcher = Matcher::new(Vec::new()).with_root(root);
 
-    assert!(!matcher.is_included("other.tmp"));
-    assert!(matcher.is_included("sub/keep.tmp"));
-    assert!(!matcher.is_included("sub/other.tmp"));
+    assert!(!matcher.is_included("other.tmp").unwrap());
+    assert!(matcher.is_included("sub/keep.tmp").unwrap());
+    assert!(!matcher.is_included("sub/other.tmp").unwrap());
 }
 
 #[test]
@@ -31,7 +31,7 @@ fn nested_filters_apply_in_order() {
 
     let matcher = Matcher::new(Vec::new()).with_root(root);
 
-    assert!(matcher.is_included("dir/debug.log"));
-    assert!(!matcher.is_included("dir/sub/debug.log"));
-    assert!(!matcher.is_included("dir/info.log"));
+    assert!(matcher.is_included("dir/debug.log").unwrap());
+    assert!(!matcher.is_included("dir/sub/debug.log").unwrap());
+    assert!(!matcher.is_included("dir/info.log").unwrap());
 }


### PR DESCRIPTION
## Summary
- return `Result` from directory rule loader and bubble errors in `Matcher::is_included`
- handle filter parse errors in sync engine
- add regression test for malformed filter files

## Testing
- `cargo test` *(fails: remote_destination_syncs: failed to read version)*
- `cargo test -p filters`
- `cargo test -p engine`


------
https://chatgpt.com/codex/tasks/task_e_68b054968b5883238728c4119df47e0f