### PR TITLE
Refactor delta computation to use windowed basis scanning

### DIFF
--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -13,6 +13,11 @@ compress = { path = "../compress" }
 [dev-dependencies]
 tempfile = "3"
 compress = { path = "../compress" }
+criterion = { version = "0.5", default-features = false }
+
+[[bench]]
+name = "large_files"
+harness = false
 
 [features]
 default = []

--- a/crates/engine/benches/large_files.rs
+++ b/crates/engine/benches/large_files.rs
@@ -1,0 +1,20 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use engine::{compute_delta, ChecksumConfigBuilder};
+use std::io::Cursor;
+
+fn bench_large_delta(c: &mut Criterion) {
+    let cfg = ChecksumConfigBuilder::new().build();
+    let block_size = 1024;
+    let window = 64;
+    let data = vec![0u8; block_size * 1024]; // 1 MiB
+    c.bench_function("compute_delta_large_file", |b| {
+        b.iter(|| {
+            let mut basis = Cursor::new(data.clone());
+            let mut target = Cursor::new(data.clone());
+            compute_delta(&cfg, &mut basis, &mut target, block_size, window).unwrap();
+        });
+    });
+}
+
+criterion_group!(benches, bench_large_delta);
+criterion_main!(benches);


### PR DESCRIPTION
## Summary
- refactor `compute_delta` to index only a rolling window of basis blocks, bounding memory usage
- expose new benchmark and large-file test validating windowed delta logic
- add Criterion bench harness for large file scenarios

## Testing
- `cargo test -p engine`
- `cargo bench --no-run`
- `cargo test` *(fails: failed to read version)*


------
https://chatgpt.com/codex/tasks/task_e_68b0579139388323a5b4797cb5287b64