### PR TITLE
feat(cli): add core flag parsing

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -35,10 +35,16 @@ rsync-rs [OPTIONS] <SRC> <DEST>
 - `-r, --recursive` – copy directories recursively.
 - `-n, --dry-run` – perform a trial run with no changes made.
 - `-v, --verbose` – increase logging verbosity.
+- `-q, --quiet` – suppress non-error messages.
 - `--delete` – remove extraneous files from the destination.
 - `-c, --checksum` – use full checksums to determine file changes.
+- `-z, --compress` – compress file data during the transfer.
 - `--stats` – display transfer statistics on completion.
 - `--config <FILE>` – supply a custom configuration file.
+
+The CLI also parses flags like `-a`, `-R`, `-P`, and `--numeric-ids`, but these
+are not yet implemented and will exit with a message directing users to
+`docs/differences.md`.
 
 For a comprehensive list of available flags and their current support status,
 see the [CLI flag reference](cli/flags.md).

--- a/docs/cli/flags.md
+++ b/docs/cli/flags.md
@@ -15,7 +15,7 @@
 |  | --fake-super | store/recover privileged attrs using xattrs | no |  | no |
 | -g | --group | preserve group | no |  | no |
 |  | --groupmap=STRING | custom groupname mapping | no |  | no |
-|  | --numeric-ids | don't map uid/gid values by user/group name | no |  | no |
+|  | --numeric-ids | don't map uid/gid values by user/group name | no | Errors out; see differences.md | no |
 | -O | --omit-dir-times | omit directories from --times | no |  | no |
 | -J | --omit-link-times | omit symlinks from --times | no |  | no |
 |  | --open-noatime | avoid changing the atime on opened files | no |  | no |
@@ -32,7 +32,7 @@
 
 | short | long | summary | implemented? | notes | enhanced? |
 | --- | --- | --- | :---: | --- | :---: |
-| -z | --compress | compress file data during the transfer | no | Parsed but not implemented | no |
+| -z | --compress | compress file data during the transfer | yes |  | no |
 |  | --compress-choice=STR | choose the compression algorithm (aka --zc) | no |  | no |
 |  | --compress-level=NUM | explicitly set compression level (aka --zl) | no |  | no |
 |  | --skip-compress=LIST | skip compressing files with suffix in LIST | no |  | no |
@@ -50,7 +50,7 @@
 | short | long | summary | implemented? | notes | enhanced? |
 | --- | --- | --- | :---: | --- | :---: |
 |  | --del | an alias for --delete-during | no |  | no |
-|  | --delete | delete extraneous files from dest dirs | no | Parsed but not implemented | no |
+|  | --delete | delete extraneous files from dest dirs | yes |  | no |
 |  | --delete-after | receiver deletes after transfer, not during | no |  | no |
 |  | --delete-before | receiver deletes before xfer, not during | no |  | no |
 |  | --delete-delay | find deletions during, delete after | no |  | no |
@@ -92,7 +92,7 @@
 |  | --stop-at=y-m-dTh:m | Stop rsync at the specified point in time | no |  | no |
 |  | --write-batch=FILE | write a batched update to FILE | no |  | no |
 | -D |  | same as --devices --specials | no |  | no |
-| -P |  | same as --partial --progress | no |  | no |
+| -P |  | same as --partial --progress | no | Errors out; see differences.md | no |
 
 ## Network
 
@@ -132,8 +132,8 @@
 |  | --no-motd | suppress daemon-mode MOTD | no |  | no |
 |  | --out-format=FORMAT | output updates using the specified FORMAT | no |  | no |
 |  | --progress | show progress during transfer | no |  | no |
-| -q | --quiet | suppress non-error messages | no |  | no |
-|  | --stats | give some file-transfer stats | no | Parsed but not implemented | no |
+| -q | --quiet | suppress non-error messages | yes |  | no |
+|  | --stats | give some file-transfer stats | yes |  | no |
 |  | --stderr=e\|a\|c | change stderr output mode (default: errors) | no |  | no |
 | -v | --verbose | increase verbosity | yes |  | no |
 | -V | --version | print the version + other info and exit | no |  | no |

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -10,11 +10,8 @@ fn client_local_sync() {
     std::fs::write(src_dir.join("a.txt"), b"hello world").unwrap();
 
     let mut cmd = Command::cargo_bin("rsync-rs").unwrap();
-    cmd.args([
-        "--local",
-        src_dir.to_str().unwrap(),
-        dst_dir.to_str().unwrap(),
-    ]);
+    let src_arg = format!("{}/", src_dir.display());
+    cmd.args(["--local", &src_arg, dst_dir.to_str().unwrap()]);
     cmd.assert().success().stdout("").stderr("");
 
     let out = std::fs::read(dst_dir.join("a.txt")).unwrap();
@@ -29,7 +26,8 @@ fn local_sync_without_flag_fails() {
     std::fs::create_dir_all(&src_dir).unwrap();
 
     let mut cmd = Command::cargo_bin("rsync-rs").unwrap();
-    cmd.args([src_dir.to_str().unwrap(), dst_dir.to_str().unwrap()]);
+    let src_arg = format!("{}/", src_dir.display());
+    cmd.args([&src_arg, dst_dir.to_str().unwrap()]);
     cmd.assert().failure();
 }
 
@@ -44,7 +42,8 @@ fn remote_destination_syncs() {
     let dst_spec = format!("remote:{}", dst_dir.to_str().unwrap());
 
     let mut cmd = Command::cargo_bin("rsync-rs").unwrap();
-    cmd.args([src_dir.to_str().unwrap(), &dst_spec]);
+    let src_arg = format!("{}/", src_dir.display());
+    cmd.args([&src_arg, &dst_spec]);
     cmd.assert().success();
 
     let out = std::fs::read(dst_dir.join("file.txt")).unwrap();
@@ -62,7 +61,8 @@ fn remote_destination_ipv6_syncs() {
     let dst_spec = format!("[::1]:{}", dst_dir.to_str().unwrap());
 
     let mut cmd = Command::cargo_bin("rsync-rs").unwrap();
-    cmd.args([src_dir.to_str().unwrap(), &dst_spec]);
+    let src_arg = format!("{}/", src_dir.display());
+    cmd.args([&src_arg, &dst_spec]);
     cmd.assert().success();
 
     let out = std::fs::read(dst_dir.join("file.txt")).unwrap();


### PR DESCRIPTION
## Summary
- support core rsync flags and quiet mode in CLI
- parse remote specs with trailing-slash semantics
- document new flag coverage and unsupported options

## Testing
- `cargo test` *(fails: remote_destination_ipv6_syncs, remote_destination_syncs; failed to read version)*

------
https://chatgpt.com/codex/tasks/task_e_68b05c5cc1708323a1518199499e17ff