### PR TITLE
Add modern compression options and negotiation

### DIFF
--- a/crates/compress/tests/codecs.rs
+++ b/crates/compress/tests/codecs.rs
@@ -6,7 +6,7 @@ const DATA: &[u8] = b"The quick brown fox jumps over the lazy dog";
 
 #[test]
 fn zlib_roundtrip() {
-    let codec = Zlib;
+    let codec = Zlib::default();
     let compressed = codec.compress(DATA).expect("compress");
     let decompressed = codec.decompress(&compressed).expect("decompress");
     assert_eq!(DATA, decompressed.as_slice());
@@ -14,7 +14,7 @@ fn zlib_roundtrip() {
 
 #[test]
 fn zstd_roundtrip() {
-    let codec = Zstd;
+    let codec = Zstd::default();
     let compressed = codec.compress(DATA).expect("compress");
     let decompressed = codec.decompress(&compressed).expect("decompress");
     assert_eq!(DATA, decompressed.as_slice());

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 thiserror = "1"
-checksums = { path = "../checksums" }
+checksums = { path = "../checksums", features = ["blake3"] }
 walk = { path = "../walk" }
 filters = { path = "../filters" }
 compress = { path = "../compress" }

--- a/crates/engine/tests/compress.rs
+++ b/crates/engine/tests/compress.rs
@@ -1,7 +1,7 @@
 use std::fs;
 
 use compress::Codec;
-use engine::{sync, SyncOptions};
+use engine::{select_codec, sync, SyncOptions};
 use filters::Matcher;
 use tempfile::tempdir;
 
@@ -58,4 +58,13 @@ fn lz4_roundtrip() {
     )
     .unwrap();
     assert_eq!(fs::read(dst.join("file.txt")).unwrap(), b"hello world");
+}
+
+#[test]
+fn codec_selection_prefers_zstd() {
+    let opts = SyncOptions { compress: true, ..Default::default() };
+    assert_eq!(select_codec(&[Codec::Zlib, Codec::Zstd], &opts), Some(Codec::Zstd));
+    assert_eq!(select_codec(&[Codec::Zlib], &opts), Some(Codec::Zlib));
+    let opts = SyncOptions { compress: true, compress_level: Some(0), ..Default::default() };
+    assert_eq!(select_codec(&[Codec::Zstd], &opts), None);
 }

--- a/docs/cli/flags.md
+++ b/docs/cli/flags.md
@@ -34,7 +34,8 @@
 | --- | --- | --- | :---: | --- | :---: |
 | -z | --compress | compress file data during the transfer | yes |  | no |
 |  | --compress-choice=STR | choose the compression algorithm (aka --zc) | no |  | no |
-|  | --compress-level=NUM | explicitly set compression level (aka --zl) | no |  | no |
+|  | --compress-level=NUM | explicitly set compression level (aka --zl) | yes |  | no |
+|  | --modern | enable zstd compression and BLAKE3 checksums | yes | rsync has no equivalent | yes |
 |  | --skip-compress=LIST | skip compressing files with suffix in LIST | no |  | no |
 
 ## Daemon

--- a/docs/differences.md
+++ b/docs/differences.md
@@ -1,0 +1,5 @@
+# Differences from rsync
+
+* Compression uses zlib by default. If both peers advertise support for zstd it will be selected automatically.
+* `--compress-level` maps the provided numeric level to the underlying codec implementation.
+* `--modern` enables zstd compression and BLAKE3 checksums on both peers.


### PR DESCRIPTION
## Summary
- default to zlib compression and prefer zstd when both peers support it
- allow `--compress-level` and `--modern` flags in the CLI
- document compression differences and add codec selection tests

## Testing
- `cargo test` *(fails: remote_destination_syncs, remote_destination_ipv6_syncs - failed to read version)*

------
https://chatgpt.com/codex/tasks/task_e_68b064e6d55c83238522da75fa08806b