### PR TITLE
Enforce SSH host key checking with configurable known_hosts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1210,6 +1210,9 @@ dependencies = [
 [[package]]
 name = "transport"
 version = "0.1.0"
+dependencies = [
+ "tempfile",
+]
 
 [[package]]
 name = "twox-hash"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4", features = ["derive", "env"] }
 engine = { path = "../engine" }
 protocol = { path = "../protocol" }
 filters = { path = "../filters" }

--- a/crates/transport/Cargo.toml
+++ b/crates/transport/Cargo.toml
@@ -2,3 +2,6 @@
 name = "transport"
 version = "0.1.0"
 edition = "2021"
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/transport/tests/ssh_unknown_host.rs
+++ b/crates/transport/tests/ssh_unknown_host.rs
@@ -1,0 +1,44 @@
+use std::process::{Command, Stdio};
+use std::thread;
+use std::time::Duration;
+
+use tempfile::NamedTempFile;
+use transport::ssh::SshStdioTransport;
+
+#[test]
+fn refuses_unknown_host_key() {
+    // Start a local SSH server in the background.
+    std::fs::create_dir_all("/run/sshd").expect("create /run/sshd");
+    let mut sshd = Command::new("/usr/sbin/sshd")
+        .arg("-D")
+        .arg("-e")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn sshd");
+
+    // Give the server a moment to start listening on port 22.
+    thread::sleep(Duration::from_millis(500));
+
+    // Use an empty known_hosts file to ensure the host key is unknown.
+    let tmp = NamedTempFile::new().expect("tmp known_hosts");
+
+    let transport = SshStdioTransport::spawn_server(
+        "localhost",
+        ["/"],
+        Some(tmp.path()),
+        true,
+    )
+    .expect("spawn ssh");
+
+    // Give the ssh process time to emit its failure message.
+    thread::sleep(Duration::from_millis(500));
+
+    let stderr = transport.stderr();
+    let msg = String::from_utf8_lossy(&stderr);
+    assert!(msg.contains("Host key verification failed"), "stderr: {msg}");
+
+    let _ = sshd.kill();
+}
+
+


### PR DESCRIPTION
## Summary
- default to strict SSH host key checking using a known_hosts file
- add CLI flags and env vars for custom known_hosts and optional opt-out
- test SSH transport refuses unknown host keys

## Testing
- `cargo test -p transport`
- `cargo test -p cli`


------
https://chatgpt.com/codex/tasks/task_e_68b06746c5c483238c3b5db14d1506f3