### PR TITLE
docs: expand cli and compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ rsync-rs is a modular reimplementation of the classic `rsync` utility in Rust. I
 
 ## Compatibility
 Platform support status is tracked in the [compatibility matrix](docs/compat_matrix.md).
+An overview of tested operating systems and interoperability notes lives in
+[docs/compatibility.md](docs/compatibility.md).
 
 ## In-Scope Features
 - Local and remote file synchronization over SSH and `rsync://`.
@@ -41,7 +43,9 @@ Platform support status is tracked in the [compatibility matrix](docs/compat_mat
 
 ## CLI
 Documentation for invoking the command line interface, available flags, and
-configuration precedence lives in [docs/cli.md](docs/cli.md).
+configuration precedence lives in [docs/cli.md](docs/cli.md). Differences from
+classic `rsync`, including how `--modern` mode alters behavior, are covered in
+[docs/differences.md](docs/differences.md).
 
 Quick links:
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -30,6 +30,17 @@ rsync-rs [OPTIONS] <SRC> <DEST>
   rsync-rs --config ./rsync-rs.toml ./src remote:/dst
   ```
 
+### Trailing slash semantics
+
+Just like `rsync`, adding a trailing slash to the source path changes what is
+copied:
+
+- `rsync-rs src/ dest/` copies the *contents* of `src` into `dest`.
+- `rsync-rs src dest/` creates a `dest/src` directory containing the original
+  files.
+- `rsync-rs remote:/src/ local/` pulls the contents of `/src` from the remote
+  host into `local`.
+
 ## Flags
 
 - `-r, --recursive` – copy directories recursively.

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1,0 +1,25 @@
+# Compatibility
+
+This page summarizes the operating systems and interoperability scenarios that
+have been exercised with `rsync-rs`. For a detailed status matrix see
+[compat_matrix.md](compat_matrix.md).
+
+## Tested platforms
+
+| Operating system | Notes |
+|------------------|-------|
+| Linux | primary development and CI platform |
+| macOS | builds and basic local sync verified |
+| Windows | under active development; path and permission handling incomplete |
+
+## Interoperability caveats
+
+* Remote transports and daemon mode are early stage and may diverge from
+  classic `rsync` behavior.
+* Many `rsync` features such as filters, hard links, xattrs, and ACLs are not
+  yet implemented.
+* `--modern` mode requires peers to understand zstd compression and BLAKE3
+  checksums.
+* Filesystem differences (case sensitivity, permissions) across platforms may
+  lead to subtle inconsistencies.
+

--- a/docs/differences.md
+++ b/docs/differences.md
@@ -1,5 +1,18 @@
 # Differences from rsync
 
-* Compression uses zlib by default. If both peers advertise support for zstd it will be selected automatically.
-* `--compress-level` maps the provided numeric level to the underlying codec implementation.
-* `--modern` enables zstd compression and BLAKE3 checksums on both peers.
+`rsync-rs` strives to mirror the traditional `rsync` command line. The table
+below highlights how common flags map to current support and how the
+`--modern` convenience flag influences behavior. For a complete listing see
+[cli/flags.md](cli/flags.md).
+
+| rsync flag | rsync-rs status | `--modern` notes |
+|------------|-----------------|------------------|
+| `-z`, `--compress` | ✅ uses zlib by default | negotiates zstd if both peers support it |
+| `--compress-level` | ✅ maps numeric levels | applies to zlib or zstd |
+| `-c`, `--checksum` | ❌ parsed but not implemented | would switch to BLAKE3 when available |
+| `-a`, `--archive` | ⚠️ parsed but exits with message | n/a |
+| `-R`, `--relative` | ⚠️ parsed but exits with message | n/a |
+| `-P` | ⚠️ parsed but exits with message | n/a |
+| `--numeric-ids` | ⚠️ parsed but exits with message | n/a |
+| `--modern` | rsync-rs only | enables zstd compression and BLAKE3 checksums |
+


### PR DESCRIPTION
## Summary
- document flag support and modern mode differences
- outline platform compatibility and interop caveats
- clarify trailing slash semantics in CLI docs and cross-link from README

## Testing
- `cargo test` *(fails: remote_destination_syncs, remote_destination_ipv6_syncs)*

------
https://chatgpt.com/codex/tasks/task_e_68b07edb09c4832388dd86c7fe94bcb5