### PR TITLE
Add filters property tests and fuzz target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,9 @@ jobs:
         run: bash scripts/interop.sh
       - name: Fuzz smoke test
         if: matrix.os == 'ubuntu-latest' && matrix.use-cross == false
-        run: timeout 30s cargo +nightly fuzz run filters_parse_fuzz -- -max_total_time=10
+        run: |
+          timeout 30s cargo +nightly fuzz run filters_parse_fuzz -- -max_total_time=10
+          timeout 30s cargo +nightly fuzz run filters -- -max_total_time=10
 
   release:
     if: startsWith(github.ref, 'refs/tags/')

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,6 +123,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "2.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -465,6 +480,7 @@ name = "filters"
 version = "0.1.0"
 dependencies = [
  "globset",
+ "proptest",
  "tempfile",
 ]
 
@@ -486,6 +502,12 @@ checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "futures"
@@ -896,6 +918,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "predicates"
 version = "3.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -935,12 +966,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fcdab19deb5195a31cf7726a210015ff1496ba1464fd42cb4f537b8b01b471f"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "lazy_static",
+ "num-traits",
+ "rand",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
 name = "protocol"
 version = "0.1.0"
 dependencies = [
  "byteorder",
  "indexmap",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
@@ -956,6 +1013,44 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -1032,6 +1127,18 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
 ]
 
 [[package]]
@@ -1225,6 +1332,12 @@ name = "typenum"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-ident"
@@ -1459,6 +1572,26 @@ checksum = "af3a19837351dc82ba89f8a125e22a3c475f05aba604acc023d62b2739ae2909"
 dependencies = [
  "libc",
  "rustix",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/crates/filters/Cargo.toml
+++ b/crates/filters/Cargo.toml
@@ -8,3 +8,4 @@ globset = "0.4"
 
 [dev-dependencies]
 tempfile = "3"
+proptest = "1"

--- a/crates/filters/tests/include_exclude.rs
+++ b/crates/filters/tests/include_exclude.rs
@@ -1,4 +1,5 @@
 use filters::{parse, Matcher};
+use proptest::prelude::*;
 
 #[test]
 fn include_and_exclude() {
@@ -8,4 +9,17 @@ fn include_and_exclude() {
     assert!(matcher.is_included("special.tmp").unwrap());
     assert!(!matcher.is_included("other.tmp").unwrap());
     assert!(matcher.is_included("notes.txt").unwrap());
+}
+
+proptest! {
+    #[test]
+    fn include_exclude_ordering(file in "[a-z]{1,8}\\.tmp") {
+        let rules = parse(&format!("+ {}\n- *.tmp\n", file)).unwrap();
+        let matcher = Matcher::new(rules);
+        prop_assert!(matcher.is_included(&file).unwrap());
+
+        let rules_rev = parse(&format!("- *.tmp\n+ {}\n", file)).unwrap();
+        let matcher_rev = Matcher::new(rules_rev);
+        prop_assert!(!matcher_rev.is_included(&file).unwrap());
+    }
 }

--- a/crates/fuzz/Cargo.toml
+++ b/crates/fuzz/Cargo.toml
@@ -23,3 +23,9 @@ name = "filters_parse_fuzz"
 path = "fuzz_targets/filters_parse_fuzz.rs"
 test = false
 doc = false
+
+[[bin]]
+name = "filters"
+path = "fuzz_targets/filters.rs"
+test = false
+doc = false

--- a/crates/fuzz/fuzz_targets/filters.rs
+++ b/crates/fuzz/fuzz_targets/filters.rs
@@ -1,0 +1,13 @@
+#![no_main]
+use filters::{parse, Matcher};
+use fuzz::helpers;
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    if let Some(s) = helpers::as_str(data) {
+        if let Ok(rules) = parse(s) {
+            let matcher = Matcher::new(rules);
+            let _ = matcher.is_included("test");
+        }
+    }
+});


### PR DESCRIPTION
## Summary
- test include/exclude ordering with proptest
- fuzz filters matcher in new cargo-fuzz target and run in CI

## Testing
- `cargo test -p filters`
- `cargo +nightly fuzz run filters -- -max_total_time=1`


------
https://chatgpt.com/codex/tasks/task_e_68b07f0dea2c8323803a2a35f282a301