### PR TITLE
Check auth file permissions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,6 +292,7 @@ dependencies = [
  "filters",
  "nix",
  "protocol",
+ "tempfile",
  "transport",
 ]
 

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -11,3 +11,6 @@ filters = { path = "../filters" }
 transport = { path = "../transport" }
 nix = { version = "0.27", features = ["fs", "user"] }
 compress = { path = "../compress" }
+
+[dev-dependencies]
+tempfile = "3"


### PR DESCRIPTION
## Summary
- require auth file be owner-only before using token
- test that insecure auth permissions are rejected

## Testing
- `cargo test -p cli`


------
https://chatgpt.com/codex/tasks/task_e_68b082534db08323b5f1ba138bea04ff