### PR TITLE
Limit captured SSH stderr and track truncation

### DIFF
--- a/crates/transport/tests/ssh_stderr_cap.rs
+++ b/crates/transport/tests/ssh_stderr_cap.rs
@@ -1,0 +1,17 @@
+use transport::ssh::SshStdioTransport;
+use transport::Transport;
+
+#[test]
+fn caps_stderr_output() {
+    const LIMIT: usize = 32 * 1024;
+    let mut transport =
+        SshStdioTransport::spawn("sh", ["-c", "head -c 100000 /dev/zero >&2"]).expect("spawn");
+
+    // wait for process to exit by draining stdout
+    let mut buf = [0u8; 1];
+    let _ = transport.receive(&mut buf).unwrap();
+
+    let (stderr, truncated) = transport.stderr();
+    assert!(truncated, "stderr not truncated");
+    assert_eq!(stderr.len(), LIMIT);
+}

--- a/crates/transport/tests/ssh_unknown_host.rs
+++ b/crates/transport/tests/ssh_unknown_host.rs
@@ -23,22 +23,19 @@ fn refuses_unknown_host_key() {
     // Use an empty known_hosts file to ensure the host key is unknown.
     let tmp = NamedTempFile::new().expect("tmp known_hosts");
 
-    let transport = SshStdioTransport::spawn_server(
-        "localhost",
-        ["/"],
-        Some(tmp.path()),
-        true,
-    )
-    .expect("spawn ssh");
+    let transport = SshStdioTransport::spawn_server("localhost", ["/"], Some(tmp.path()), true)
+        .expect("spawn ssh");
 
     // Give the ssh process time to emit its failure message.
     thread::sleep(Duration::from_millis(500));
 
-    let stderr = transport.stderr();
+    let (stderr, truncated) = transport.stderr();
+    assert!(!truncated);
     let msg = String::from_utf8_lossy(&stderr);
-    assert!(msg.contains("Host key verification failed"), "stderr: {msg}");
+    assert!(
+        msg.contains("Host key verification failed"),
+        "stderr: {msg}"
+    );
 
     let _ = sshd.kill();
 }
-
-


### PR DESCRIPTION
## Summary
- capture SSH stderr in a fixed-size buffer and note when output is truncated
- expose stderr along with truncation flag
- test that oversized stderr is capped

## Testing
- `cargo test -p cli`
- `cargo test -p transport`


------
https://chatgpt.com/codex/tasks/task_e_68b082590a888323a1325c5023a2d6b8