### PR TITLE
Stream delta operations via iterator

### DIFF
--- a/crates/engine/benches/large_files.rs
+++ b/crates/engine/benches/large_files.rs
@@ -1,6 +1,7 @@
+use checksums::ChecksumConfigBuilder;
 use criterion::{criterion_group, criterion_main, Criterion};
-use engine::{compute_delta, ChecksumConfigBuilder};
-use std::io::Cursor;
+use engine::compute_delta;
+use std::io::{Cursor, Read, Seek, SeekFrom};
 
 fn bench_large_delta(c: &mut Criterion) {
     let cfg = ChecksumConfigBuilder::new().build();
@@ -11,10 +12,66 @@ fn bench_large_delta(c: &mut Criterion) {
         b.iter(|| {
             let mut basis = Cursor::new(data.clone());
             let mut target = Cursor::new(data.clone());
-            compute_delta(&cfg, &mut basis, &mut target, block_size, window).unwrap();
+            for op in compute_delta(&cfg, &mut basis, &mut target, block_size, window).unwrap() {
+                op.unwrap();
+            }
         });
     });
 }
 
-criterion_group!(benches, bench_large_delta);
+struct ZeroReader {
+    pos: u64,
+    len: u64,
+}
+
+impl ZeroReader {
+    fn new(len: u64) -> Self {
+        Self { pos: 0, len }
+    }
+}
+
+impl Read for ZeroReader {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        if self.pos >= self.len {
+            return Ok(0);
+        }
+        let remain = (self.len - self.pos) as usize;
+        let n = remain.min(buf.len());
+        for b in &mut buf[..n] {
+            *b = 0;
+        }
+        self.pos += n as u64;
+        Ok(n)
+    }
+}
+
+impl Seek for ZeroReader {
+    fn seek(&mut self, pos: SeekFrom) -> std::io::Result<u64> {
+        let new = match pos {
+            SeekFrom::Start(o) => o as i64,
+            SeekFrom::End(o) => self.len as i64 + o,
+            SeekFrom::Current(o) => self.pos as i64 + o,
+        };
+        self.pos = new as u64;
+        Ok(self.pos)
+    }
+}
+
+fn bench_streaming_delta(c: &mut Criterion) {
+    let cfg = ChecksumConfigBuilder::new().build();
+    let block_size = 1024;
+    let window = 64;
+    let len = 2 * 1024 * 1024 * 1024u64; // 2 GiB
+    c.bench_function("stream_delta_2gb_zero", |b| {
+        b.iter(|| {
+            let mut basis = ZeroReader::new(len);
+            let mut target = ZeroReader::new(len);
+            for op in compute_delta(&cfg, &mut basis, &mut target, block_size, window).unwrap() {
+                op.unwrap();
+            }
+        });
+    });
+}
+
+criterion_group!(benches, bench_large_delta, bench_streaming_delta);
 criterion_main!(benches);


### PR DESCRIPTION
## Summary
- Stream delta operations using `DeltaIter` instead of buffering to `Vec`
- Apply deltas incrementally in sender/receiver pipeline
- Add benchmarks with a virtual 2 GiB file to exercise bounded-memory streaming

## Testing
- `cargo test -p engine`
- `cargo check -p engine --benches`
- `cargo test` *(fails: remote_destination_syncs, remote_destination_ipv6_syncs)*

------
https://chatgpt.com/codex/tasks/task_e_68b082568878832385e2b4a2f6dbdc35