### PR TITLE
Use meta crate for metadata handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -435,10 +435,10 @@ dependencies = [
  "criterion",
  "filetime",
  "filters",
+ "meta",
  "nix",
  "tempfile",
  "thiserror",
- "users",
  "walk",
  "xattr",
 ]
@@ -1103,12 +1103,14 @@ dependencies = [
  "engine",
  "filters",
  "nix",
+ "posix-acl",
  "predicates",
  "protocol",
  "serde",
  "serde_json",
  "serial_test",
  "tempfile",
+ "xattr",
 ]
 
 [[package]]
@@ -1347,16 +1349,6 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
-
-[[package]]
-name = "users"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24cc0f6d6f267b73e5a2cadf007ba8f9bc39c6a6f9666f8cf25ea809a153b032"
-dependencies = [
- "libc",
- "log",
-]
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,15 @@ assert_cmd = "2"
 predicates = "3"
 serial_test = "2"
 nix = { version = "0.27", features = ["user", "fs"] }
+xattr = "1.3"
+posix-acl = "1.2"
 
 [[bin]]
 name = "flag_matrix"
 path = "tools/flag_matrix.rs"
+
+[features]
+default = []
+lz4 = ["engine/lz4"]
+xattr = ["engine/xattr", "cli/xattr"]
+acl = ["engine/acl", "cli/acl"]

--- a/bin/rsync-rs/Cargo.toml
+++ b/bin/rsync-rs/Cargo.toml
@@ -10,3 +10,8 @@ path = "src/main.rs"
 [dependencies]
 cli = { path = "../../crates/cli" }
 engine = { path = "../../crates/engine" }
+
+[features]
+default = []
+xattr = ["engine/xattr", "cli/xattr"]
+acl = ["engine/acl", "cli/acl"]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -14,3 +14,8 @@ compress = { path = "../compress" }
 
 [dev-dependencies]
 tempfile = "3"
+
+[features]
+default = []
+xattr = ["engine/xattr"]
+acl = ["engine/acl"]

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -9,15 +9,15 @@ checksums = { path = "../checksums", features = ["blake3"] }
 walk = { path = "../walk" }
 filters = { path = "../filters" }
 compress = { path = "../compress" }
-filetime = "0.2"
 nix = { version = "0.27", features = ["user", "fs"] }
-xattr = "1.3"
-users = "0.11"
+meta = { path = "../meta", default-features = false }
 
 [dev-dependencies]
 tempfile = "3"
 compress = { path = "../compress" }
 criterion = { version = "0.5", default-features = false }
+filetime = "0.2"
+xattr = "1.3"
 
 [[bench]]
 name = "large_files"
@@ -26,3 +26,5 @@ harness = false
 [features]
 default = []
 lz4 = ["compress/lz4"]
+xattr = ["meta/xattr"]
+acl = ["meta/acl"]

--- a/crates/engine/tests/attrs.rs
+++ b/crates/engine/tests/attrs.rs
@@ -131,6 +131,7 @@ fn hard_links_roundtrip() {
     assert_eq!(m1.ino(), m2.ino());
 }
 
+#[cfg(feature = "xattr")]
 #[test]
 fn xattrs_roundtrip() {
     let tmp = tempdir().unwrap();
@@ -153,6 +154,7 @@ fn xattrs_roundtrip() {
     assert_eq!(&val[..], b"val");
 }
 
+#[cfg(feature = "acl")]
 #[test]
 fn acls_roundtrip() {
     let tmp = tempdir().unwrap();

--- a/tests/local_sync_tree.rs
+++ b/tests/local_sync_tree.rs
@@ -3,6 +3,8 @@ use std::collections::BTreeMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 use tempfile::tempdir;
+#[cfg(unix)]
+use std::os::unix::fs::{FileTypeExt, MetadataExt};
 
 fn collect(dir: &Path) -> BTreeMap<PathBuf, Vec<u8>> {
     fn visit(base: &Path, root: &Path, map: &mut BTreeMap<PathBuf, Vec<u8>>) {
@@ -41,4 +43,120 @@ fn sync_directory_tree() {
         .stderr("");
 
     assert_eq!(collect(&src), collect(&dst));
+}
+
+#[cfg(all(unix, feature = "xattr"))]
+#[test]
+fn sync_preserves_xattrs() {
+    let tmp = tempdir().unwrap();
+    let src = tmp.path().join("src");
+    let dst = tmp.path().join("dst");
+    fs::create_dir_all(&src).unwrap();
+    fs::create_dir_all(&dst).unwrap();
+    let file = src.join("file");
+    fs::write(&file, b"hi").unwrap();
+    xattr::set(&file, "user.test", b"val").unwrap();
+
+    let src_arg = format!("{}/", src.display());
+    Command::cargo_bin("rsync-rs")
+        .unwrap()
+        .args(["--local", "--xattrs", &src_arg, dst.to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout("")
+        .stderr("");
+
+    let val = xattr::get(dst.join("file"), "user.test").unwrap().unwrap();
+    assert_eq!(&val[..], b"val");
+}
+
+#[cfg(all(unix, feature = "acl"))]
+#[test]
+fn sync_preserves_acls() {
+    use posix_acl::{PosixACL, Qualifier, ACL_READ};
+
+    let tmp = tempdir().unwrap();
+    let src = tmp.path().join("src");
+    let dst = tmp.path().join("dst");
+    fs::create_dir_all(&src).unwrap();
+    fs::create_dir_all(&dst).unwrap();
+    let file = src.join("file");
+    fs::write(&file, b"hi").unwrap();
+
+    let mut acl = PosixACL::read_acl(&file).unwrap();
+    acl.set(Qualifier::User(12345), ACL_READ);
+    acl.write_acl(&file).unwrap();
+
+    let src_arg = format!("{}/", src.display());
+    Command::cargo_bin("rsync-rs")
+        .unwrap()
+        .args(["--local", "--acls", &src_arg, dst.to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout("")
+        .stderr("");
+
+    let acl_src = PosixACL::read_acl(&file).unwrap();
+    let acl_dst = PosixACL::read_acl(&dst.join("file")).unwrap();
+    assert_eq!(acl_src.entries(), acl_dst.entries());
+}
+
+#[cfg(unix)]
+#[test]
+fn sync_preserves_device_nodes() {
+    use nix::sys::stat::{mknod, makedev, Mode, SFlag};
+
+    let tmp = tempdir().unwrap();
+    let src = tmp.path().join("src");
+    let dst = tmp.path().join("dst");
+    fs::create_dir_all(&src).unwrap();
+    fs::create_dir_all(&dst).unwrap();
+    let dev = src.join("null");
+    mknod(
+        &dev,
+        SFlag::S_IFCHR,
+        Mode::from_bits_truncate(0o600),
+        makedev(1, 3),
+    )
+    .unwrap();
+
+    let src_arg = format!("{}/", src.display());
+    Command::cargo_bin("rsync-rs")
+        .unwrap()
+        .args(["--local", "--devices", &src_arg, dst.to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout("")
+        .stderr("");
+
+    let meta = fs::symlink_metadata(dst.join("null")).unwrap();
+    assert!(meta.file_type().is_char_device());
+    assert_eq!(meta.rdev(), makedev(1, 3));
+}
+
+#[cfg(unix)]
+#[test]
+fn sync_preserves_hard_links() {
+    let tmp = tempdir().unwrap();
+    let src = tmp.path().join("src");
+    let dst = tmp.path().join("dst");
+    fs::create_dir_all(&src).unwrap();
+    fs::create_dir_all(&dst).unwrap();
+    let f1 = src.join("f1");
+    fs::write(&f1, b"hi").unwrap();
+    let f2 = src.join("f2");
+    fs::hard_link(&f1, &f2).unwrap();
+
+    let src_arg = format!("{}/", src.display());
+    Command::cargo_bin("rsync-rs")
+        .unwrap()
+        .args(["--local", "--hard-links", &src_arg, dst.to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout("")
+        .stderr("");
+
+    let m1 = fs::metadata(dst.join("f1")).unwrap();
+    let m2 = fs::metadata(dst.join("f2")).unwrap();
+    assert_eq!(m1.ino(), m2.ino());
 }


### PR DESCRIPTION
## Summary
- Replace manual metadata copying with `meta::Metadata::from_path` and `apply`
- Gate extended attribute and ACL code behind optional features
- Add integration tests for xattrs, ACLs, device nodes and hard links

## Testing
- `cargo test --features "xattr acl"`
- `cargo test --features "xattr acl" -p engine`
- `cargo test --features "xattr acl" -p meta`
- `cargo test --all --features "xattr acl"` *(fails: test `ssh_unknown_host` in crate `transport`)*

------
https://chatgpt.com/codex/tasks/task_e_68b095ef09808323b1f757d7d46ea276