### PR TITLE
docs: track current gaps

### DIFF
--- a/docs/gaps.md
+++ b/docs/gaps.md
@@ -1,0 +1,24 @@
+# Project Gaps
+
+This document tracks outstanding gaps in `rsync-rs` compared to the reference `rsync` implementation. Update this file as features are implemented.
+
+## Missing rsync behaviors
+- Checksum-based skipping via `-c/--checksum` is parsed but still unimplemented.
+- Deletion flags other than `--delete` are not supported.
+- Many command-line options remain absent or lack parity; see `docs/feature_matrix.md` for the full matrix.
+
+## Unreachable code
+- No `unreachable!` or similar markers were found in the current codebase, but manual audit may reveal latent issues.
+
+## TODOs
+- No `TODO` markers are present in the repository at this time.
+
+## Test coverage gaps
+- `tests/golden/cli_parity/delete.sh` skips its parity check when `rsync-rs --delete` fails, leaving deletion behavior partially untested.
+- `tests/remote_remote.rs` contains an ignored test (`remote_to_remote_pipes_data`) for remote-to-remote transfers.
+- Many CLI options listed in `docs/feature_matrix.md` have no associated tests.
+
+## Continuous integration deficiencies
+- The CI matrix omits Windows runners, limiting cross-platform assurance.
+- Coverage reporting is absent from CI.
+- Fuzzing in CI is limited to short smoke tests and may miss deeper issues.


### PR DESCRIPTION
## Summary
- add documentation tracking missing behaviors, test gaps, and CI deficiencies

## Testing
- `cargo -Znext-lockfile-bump test`

------
https://chatgpt.com/codex/tasks/task_e_68b0a1f1be908323a3d69c3c5cc0b0ad