### PR TITLE
ci: add windows build, coverage, and nightly fuzz

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     branches: ["main"]
     tags: ["v*"]
   pull_request:
+  schedule:
+    - cron: '0 0 * * *'
 
 jobs:
   test:
@@ -22,6 +24,9 @@ jobs:
             use-cross: true
           - os: macos-latest
             target: x86_64-apple-darwin
+            use-cross: false
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
             use-cross: false
     steps:
       - uses: actions/checkout@v3
@@ -60,8 +65,20 @@ jobs:
           else
             cargo test --all --target ${{ matrix.target }}
           fi
+      - name: Install cargo-tarpaulin
+        if: matrix.os == 'ubuntu-latest' && matrix.use-cross == false
+        run: cargo install cargo-tarpaulin --locked
+      - name: Coverage
+        if: matrix.os == 'ubuntu-latest' && matrix.use-cross == false
+        run: cargo tarpaulin --out Xml --output-dir coverage
+      - name: Upload coverage report
+        if: matrix.os == 'ubuntu-latest' && matrix.use-cross == false
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-${{ matrix.target }}
+          path: coverage
       - name: Golden parity tests
-        if: matrix.use-cross == false
+        if: matrix.use-cross == false && matrix.os != 'windows-latest'
         run: make test-golden
       - name: Interop tests
         if: matrix.os == 'ubuntu-latest' && matrix.use-cross == false
@@ -72,8 +89,8 @@ jobs:
       - name: Fuzz smoke test
         if: matrix.os == 'ubuntu-latest' && matrix.use-cross == false
         run: |
-          timeout 30s cargo +nightly fuzz run filters_parse_fuzz -- -max_total_time=10
-          timeout 30s cargo +nightly fuzz run filters -- -max_total_time=10
+          timeout 60s cargo +nightly fuzz run filters_parse_fuzz -- -max_total_time=30
+          timeout 60s cargo +nightly fuzz run filters -- -max_total_time=30
 
   release:
     if: startsWith(github.ref, 'refs/tags/')
@@ -114,3 +131,19 @@ jobs:
         with:
           name: rsync-rs-${{ matrix.target }}
           path: target/${{ matrix.target }}/release/rsync-rs
+
+  nightly-fuzz:
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          override: true
+      - run: cargo install cargo-fuzz --locked
+      - name: Run fuzzers
+        run: |
+          cargo +nightly fuzz run filters_parse_fuzz -- -max_total_time=300
+          cargo +nightly fuzz run filters -- -max_total_time=300


### PR DESCRIPTION
## Summary
- build and test on Windows
- collect Linux coverage using tarpaulin
- run extended fuzzing on nightly schedule

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68b0aa9c10ac83238123a437a8bd5eba