### PR TITLE
Add exit-code mapping and golden frame tests for protocol crate

### DIFF
--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -12,6 +12,8 @@ use std::io::{self, Read, Write};
 
 pub mod demux;
 pub mod mux;
+pub use demux::Demux;
+pub use mux::Mux;
 
 /// Latest protocol version supported by this implementation.
 pub const LATEST_VERSION: u32 = 31;
@@ -138,6 +140,92 @@ impl TryFrom<u8> for Msg {
             7 => Ok(Msg::Progress),
             other => Err(UnknownMsg(other)),
         }
+    }
+}
+
+/// Exit codes returned by rsync processes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum ExitCode {
+    Ok = 0,
+    SyntaxOrUsage = 1,
+    Protocol = 2,
+    FileSelect = 3,
+    Unsupported = 4,
+    StartClient = 5,
+    SocketIo = 10,
+    FileIo = 11,
+    StreamIo = 12,
+    MessageIo = 13,
+    Ipc = 14,
+    Crashed = 15,
+    Terminated = 16,
+    Signal1 = 19,
+    Signal = 20,
+    WaitChild = 21,
+    Malloc = 22,
+    Partial = 23,
+    Vanished = 24,
+    DelLimit = 25,
+    Timeout = 30,
+    ConnTimeout = 35,
+    CmdFailed = 124,
+    CmdKilled = 125,
+    CmdRun = 126,
+    CmdNotFound = 127,
+}
+
+/// Error returned when converting from an unknown exit code.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct UnknownExit(pub u8);
+
+impl fmt::Display for UnknownExit {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "unknown exit code {}", self.0)
+    }
+}
+
+impl std::error::Error for UnknownExit {}
+
+impl TryFrom<u8> for ExitCode {
+    type Error = UnknownExit;
+
+    fn try_from(v: u8) -> Result<Self, Self::Error> {
+        match v {
+            0 => Ok(ExitCode::Ok),
+            1 => Ok(ExitCode::SyntaxOrUsage),
+            2 => Ok(ExitCode::Protocol),
+            3 => Ok(ExitCode::FileSelect),
+            4 => Ok(ExitCode::Unsupported),
+            5 => Ok(ExitCode::StartClient),
+            10 => Ok(ExitCode::SocketIo),
+            11 => Ok(ExitCode::FileIo),
+            12 => Ok(ExitCode::StreamIo),
+            13 => Ok(ExitCode::MessageIo),
+            14 => Ok(ExitCode::Ipc),
+            15 => Ok(ExitCode::Crashed),
+            16 => Ok(ExitCode::Terminated),
+            19 => Ok(ExitCode::Signal1),
+            20 => Ok(ExitCode::Signal),
+            21 => Ok(ExitCode::WaitChild),
+            22 => Ok(ExitCode::Malloc),
+            23 => Ok(ExitCode::Partial),
+            24 => Ok(ExitCode::Vanished),
+            25 => Ok(ExitCode::DelLimit),
+            30 => Ok(ExitCode::Timeout),
+            35 => Ok(ExitCode::ConnTimeout),
+            124 => Ok(ExitCode::CmdFailed),
+            125 => Ok(ExitCode::CmdKilled),
+            126 => Ok(ExitCode::CmdRun),
+            127 => Ok(ExitCode::CmdNotFound),
+            other => Err(UnknownExit(other)),
+        }
+    }
+}
+
+impl From<ExitCode> for u8 {
+    fn from(e: ExitCode) -> Self {
+        e as u8
     }
 }
 

--- a/crates/protocol/tests/exit_codes.rs
+++ b/crates/protocol/tests/exit_codes.rs
@@ -1,0 +1,23 @@
+use protocol::ExitCode;
+use std::convert::TryFrom;
+
+#[test]
+fn exit_code_roundtrip() {
+    let codes = [
+        (0u8, ExitCode::Ok),
+        (1, ExitCode::SyntaxOrUsage),
+        (2, ExitCode::Protocol),
+        (23, ExitCode::Partial),
+        (127, ExitCode::CmdNotFound),
+    ];
+    for (num, code) in codes {
+        assert_eq!(ExitCode::try_from(num).unwrap(), code);
+        let back: u8 = code.into();
+        assert_eq!(back, num);
+    }
+}
+
+#[test]
+fn unknown_exit_code_errors() {
+    assert!(ExitCode::try_from(99u8).is_err());
+}

--- a/crates/protocol/tests/golden_frames.rs
+++ b/crates/protocol/tests/golden_frames.rs
@@ -1,0 +1,37 @@
+use protocol::{Frame, Message, Msg, Tag};
+
+#[test]
+fn decode_version_golden() {
+    const VERSION: [u8; 12] = [0, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0, 31];
+    let frame = Frame::decode(&VERSION[..]).unwrap();
+    assert_eq!(frame.header.msg, Msg::Version);
+    let msg = Message::from_frame(frame).unwrap();
+    assert_eq!(msg, Message::Version(31));
+}
+
+#[test]
+fn decode_keepalive_golden() {
+    const KEEPALIVE: [u8; 8] = [0, 0, 1, 3, 0, 0, 0, 0];
+    let frame = Frame::decode(&KEEPALIVE[..]).unwrap();
+    assert_eq!(frame.header.tag, Tag::KeepAlive);
+    let msg = Message::from_frame(frame).unwrap();
+    assert_eq!(msg, Message::KeepAlive);
+}
+
+#[test]
+fn decode_progress_golden() {
+    const PROG: [u8; 16] = [0, 0, 0, 7, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 0x30, 0x39];
+    let frame = Frame::decode(&PROG[..]).unwrap();
+    assert_eq!(frame.header.msg, Msg::Progress);
+    let msg = Message::from_frame(frame).unwrap();
+    assert_eq!(msg, Message::Progress(0x3039));
+}
+
+#[test]
+fn decode_error_golden() {
+    const ERR: [u8; 12] = [0, 0, 0, 6, 0, 0, 0, 4, b'o', b'o', b'p', b's'];
+    let frame = Frame::decode(&ERR[..]).unwrap();
+    assert_eq!(frame.header.msg, Msg::Error);
+    let msg = Message::from_frame(frame).unwrap();
+    assert_eq!(msg, Message::Error("oops".to_string()));
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -34,6 +34,19 @@ It can spawn `ssh` in server mode (`--server` arguments) and capture the
 process's stderr for diagnostics. Child stdio is wrapped in buffered readers and
 writers to ensure bounded I/O when communicating with remote peers.
 
+## Version and capability negotiation
+
+Every session begins with a handshake where both peers advertise the highest
+protocol version they support along with a bitmask of optional capabilities.
+The `protocol` crate compares the peer's version with its own range of
+[`MIN_VERSION`](../crates/protocol/src/lib.rs) through
+[`LATEST_VERSION`](../crates/protocol/src/lib.rs) and selects the highest common
+value. Capabilities are negotiated by intersecting the advertised bitmasks so
+that both sides enable only features understood by each. If no overlap exists
+the handshake fails with a negotiation error. Subsequent messages—including
+keep-alives, progress updates and error reports—operate within the agreed
+version and capability set.
+
 ## Data flow
 
 1. The [`walk`](../crates/walk) crate scans the filesystem and yields metadata


### PR DESCRIPTION
## Summary
- expose mux/demux and map rsync exit codes to strongly-typed `ExitCode`
- add golden frame decoding tests and round-trip exit-code checks
- document version and capability negotiation in architecture overview

## Testing
- `cargo test -p protocol`


------
https://chatgpt.com/codex/tasks/task_e_68b0baeac9308323890aaee4797077de