### PR TITLE
docs: update gaps listing

### DIFF
--- a/docs/gaps.md
+++ b/docs/gaps.md
@@ -3,8 +3,9 @@
 This document tracks outstanding gaps in `rsync-rs` compared to the reference `rsync` implementation. Update this file as features are implemented.
 
 ## Missing rsync behaviors
-- Checksum-based skipping via `-c/--checksum` is parsed but still unimplemented.
-- Deletion flags other than `--delete` are not supported.
+- Filter rules are incomplete and do not yet match `rsync`'s full include/exclude syntax.
+- Compression negotiation between peers is unimplemented.
+- Daemon authentication support is missing.
 - Many command-line options remain absent or lack parity; see `docs/feature_matrix.md` for the full matrix.
 
 ## Unreachable code
@@ -14,10 +15,11 @@ This document tracks outstanding gaps in `rsync-rs` compared to the reference `r
 - No `TODO` markers are present in the repository at this time.
 
 ## Test coverage gaps
-- `tests/golden/cli_parity/delete.sh` skips its parity check when `rsync-rs --delete` fails, leaving deletion behavior partially untested.
-- `tests/remote_remote.rs` contains an ignored test (`remote_to_remote_pipes_data`) for remote-to-remote transfers.
+- `tests/golden/cli_parity/delete.sh` skips parity checks for deletion flags that are unimplemented or fail, which can hide gaps in deletion behavior.
+- `tests/remote_remote.rs` exercises remote-to-remote transfers but only covers a basic pipe scenario.
 - Many CLI options listed in `docs/feature_matrix.md` have no associated tests.
 
 ## Continuous integration deficiencies
 - Coverage is collected on Linux and Windows using `cargo-llvm-cov`, but no thresholds are enforced.
 - Nightly jobs fuzz all targets for longer runs, yet pull requests still rely on brief smoke tests.
+- Remote-to-remote transfers, filter rules, compression negotiation, and daemon authentication lack dedicated CI coverage.


### PR DESCRIPTION
## Summary
- clarify outstanding gaps for filters, compression negotiation, and daemon auth
- document limited coverage for remote transfers and deletion parity scripts
- note missing CI coverage for several features

## Testing
- `cargo test` *(fails: remote_to_remote_pipes_data)*

------
https://chatgpt.com/codex/tasks/task_e_68b0c211f7348323bc7e73721f29b596