### PR TITLE
Add coverage for supported CLI flags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1102,6 +1102,7 @@ dependencies = [
  "cli",
  "compress",
  "engine",
+ "filetime",
  "filters",
  "nix",
  "posix-acl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ nix = { version = "0.27", features = ["user", "fs"] }
 xattr = "1.3"
 posix-acl = "1.2"
 transport = { path = "crates/transport" }
+filetime = "0.2"
 
 [[bin]]
 name = "flag_matrix"

--- a/docs/feature_matrix.md
+++ b/docs/feature_matrix.md
@@ -6,14 +6,14 @@ This table tracks the implementation status of rsync 3.2.x command-line options.
 
 | Option | Supported | Behavior Parity | Tests | Notes |
 |-------|-----------|-----------------|-------|-------|
-| `--verbose, -v` | ✅ |  |  |  |
+| `--verbose, -v` | ✅ |  | [tests/cli.rs](../tests/cli.rs) |  |
 | `--info=FLAGS` |  |  |  |  |
 | `--debug=FLAGS` |  |  |  |  |
 | `--stderr=e|a|c` |  |  |  |  |
-| `--quiet, -q` | ✅ |  |  |  |
+| `--quiet, -q` | ✅ |  | [tests/cli.rs](../tests/cli.rs) |  |
 | `--no-motd` |  |  |  |  |
-| `--checksum, -c` | ✅ |  |  |  |
-| `--archive, -a` | ✅ |  |  |  |
+| `--checksum, -c` | ✅ |  | [tests/cli.rs](../tests/cli.rs) |  |
+| `--archive, -a` | ✅ |  | [tests/cli.rs](../tests/cli.rs) |  |
 | `--no-OPTION` |  |  |  |  |
 | `--recursive, -r` | ✅ | ✅ | [tests/golden/cli_parity/compression.sh](../tests/golden/cli_parity/compression.sh)<br>[tests/golden/cli_parity/delete.sh](../tests/golden/cli_parity/delete.sh)<br>[tests/golden/cli_parity/selection.sh](../tests/golden/cli_parity/selection.sh) |  |
 | `--relative, -R` | ✅ |  | [tests/cli.rs](../tests/cli.rs) |  |
@@ -58,7 +58,7 @@ This table tracks the implementation status of rsync 3.2.x command-line options.
 | `--fake-super` |  |  |  |  |
 | `--sparse, -S` | ✅ |  | [crates/engine/tests/attrs.rs](../crates/engine/tests/attrs.rs) |  |
 | `--preallocate` |  |  |  |  |
-| `--dry-run, -n` | ✅ |  |  |  |
+| `--dry-run, -n` | ✅ |  | [tests/cli.rs](../tests/cli.rs) |  |
 | `--whole-file, -W` |  |  |  |  |
 | `--checksum-choice=STR` |  |  |  |  |
 | `--one-file-system, -x` |  |  |  |  |
@@ -103,7 +103,7 @@ This table tracks the implementation status of rsync 3.2.x command-line options.
 | `--link-dest=DIR` |  |  |  |  |
 | `--compress, -z` | ✅ | ✅ | [tests/golden/cli_parity/compression.sh](../tests/golden/cli_parity/compression.sh) |  |
 | `--compress-choice=STR` |  |  |  |  |
-| `--compress-level=NUM` | ✅ |  |  |  |
+| `--compress-level=NUM` | ✅ |  | [tests/golden/cli_parity/compress-level.sh](../tests/golden/cli_parity/compress-level.sh)<br>[tests/cli.rs](../tests/cli.rs) |  |
 | `--skip-compress=LIST` |  |  |  |  |
 | `--cvs-exclude, -C` |  |  |  |  |
 | `--filter=RULE, -f` | ✅ | ✅ | [tests/golden/cli_parity/selection.sh](../tests/golden/cli_parity/selection.sh) |  |
@@ -119,11 +119,11 @@ This table tracks the implementation status of rsync 3.2.x command-line options.
 | `--trust-sender` |  |  |  |  |
 | `--copy-as=USER[:GROUP]` |  |  |  |  |
 | `--address=ADDRESS` |  |  |  |  |
-| `--port=PORT` | ✅ |  |  |  |
+| `--port=PORT` | ✅ |  | [tests/daemon.rs](../tests/daemon.rs)<br>[tests/cli.rs](../tests/cli.rs) |  |
 | `--sockopts=OPTIONS` |  |  |  |  |
 | `--blocking-io` |  |  |  |  |
 | `--outbuf=N|L|B` |  |  |  |  |
-| `--stats` | ✅ |  |  |  |
+| `--stats` | ✅ |  | [tests/cli.rs](../tests/cli.rs) |  |
 | `--8-bit-output, -8` |  |  |  |  |
 | `--human-readable, -h` |  |  |  |  |
 | `--progress` |  |  |  |  |
@@ -151,7 +151,7 @@ This table tracks the implementation status of rsync 3.2.x command-line options.
 | `--version, -V` |  |  |  |  |
 | `--help, -h (*)` |  |  |  |  |
 | `--daemon` | ✅ |  | [tests/daemon.rs](../tests/daemon.rs) |  |
-| `--config=FILE` | ✅ |  |  |  |
+| `--config=FILE` | ✅ |  | [tests/cli.rs](../tests/cli.rs) |  |
 | `--dparam=OVERRIDE, -M` |  |  |  |  |
 | `--no-detach` |  |  |  |  |
 | `--help, -h` |  |  |  |  |

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,4 +1,5 @@
 use assert_cmd::Command;
+use filetime::{set_file_mtime, FileTime};
 #[cfg(unix)]
 use nix::unistd::{chown, Gid, Uid};
 #[cfg(unix)]
@@ -170,4 +171,164 @@ fn numeric_ids_are_preserved() {
         assert_eq!(meta.uid(), 12345);
         assert_eq!(meta.gid(), 12345);
     }
+}
+
+#[test]
+fn verbose_flag_increases_logging() {
+    let dir = tempdir().unwrap();
+    let src_dir = dir.path().join("src");
+    let dst_dir = dir.path().join("dst");
+    std::fs::create_dir_all(&src_dir).unwrap();
+
+    let mut cmd = Command::cargo_bin("rsync-rs").unwrap();
+    let src_arg = format!("{}/", src_dir.display());
+    cmd.args(["--local", "--verbose", &src_arg, dst_dir.to_str().unwrap()]);
+    cmd.assert()
+        .success()
+        .stdout(predicates::str::contains("verbose level set to 1"));
+}
+
+#[test]
+fn quiet_flag_suppresses_output() {
+    let dir = tempdir().unwrap();
+    let src_dir = dir.path().join("src");
+    let dst_dir = dir.path().join("dst");
+    std::fs::create_dir_all(&src_dir).unwrap();
+
+    let mut cmd = Command::cargo_bin("rsync-rs").unwrap();
+    let src_arg = format!("{}/", src_dir.display());
+    cmd.args([
+        "--local",
+        "--recursive",
+        "--quiet",
+        &src_arg,
+        dst_dir.to_str().unwrap(),
+    ]);
+    cmd.assert().success().stdout("").stderr("");
+}
+
+#[test]
+fn archive_implies_recursive() {
+    let dir = tempdir().unwrap();
+    let src_root = dir.path().join("src");
+    std::fs::create_dir_all(src_root.join("a/b")).unwrap();
+    std::fs::write(src_root.join("a/b/file.txt"), b"hi").unwrap();
+    let dst_dir = dir.path().join("dst");
+
+    let mut cmd = Command::cargo_bin("rsync-rs").unwrap();
+    let src_arg = format!("{}/", src_root.display());
+    cmd.args(["--local", "-a", &src_arg, dst_dir.to_str().unwrap()]);
+    cmd.assert().success();
+    assert!(dst_dir.join("a/b/file.txt").exists());
+}
+
+#[test]
+fn dry_run_does_not_modify_destination() {
+    let dir = tempdir().unwrap();
+    let src_dir = dir.path().join("src");
+    let dst_dir = dir.path().join("dst");
+    std::fs::create_dir_all(&src_dir).unwrap();
+    std::fs::write(src_dir.join("file.txt"), b"hello").unwrap();
+
+    let mut cmd = Command::cargo_bin("rsync-rs").unwrap();
+    let src_arg = format!("{}/", src_dir.display());
+    cmd.args(["--local", "--dry-run", &src_arg, dst_dir.to_str().unwrap()]);
+    cmd.assert().success();
+    assert!(!dst_dir.join("file.txt").exists());
+}
+
+#[test]
+fn checksum_forces_transfer_cli() {
+    let dir = tempdir().unwrap();
+    let src = dir.path().join("src");
+    let dst = dir.path().join("dst");
+    std::fs::create_dir_all(&src).unwrap();
+    std::fs::create_dir_all(&dst).unwrap();
+    let src_file = src.join("file");
+    let dst_file = dst.join("file");
+    std::fs::write(&src_file, b"aaaa").unwrap();
+    std::fs::write(&dst_file, b"bbbb").unwrap();
+    let mtime = FileTime::from_unix_time(1_000_000, 0);
+    set_file_mtime(&src_file, mtime).unwrap();
+    set_file_mtime(&dst_file, mtime).unwrap();
+
+    Command::cargo_bin("rsync-rs")
+        .unwrap()
+        .args([
+            "--local",
+            &format!("{}/", src.display()),
+            dst.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+    assert_eq!(std::fs::read(&dst_file).unwrap(), b"bbbb");
+
+    Command::cargo_bin("rsync-rs")
+        .unwrap()
+        .args([
+            "--local",
+            "--checksum",
+            &format!("{}/", src.display()),
+            dst.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+    assert_eq!(std::fs::read(&dst_file).unwrap(), b"aaaa");
+}
+
+#[test]
+fn stats_are_printed() {
+    let dir = tempdir().unwrap();
+    let src_dir = dir.path().join("src");
+    let dst_dir = dir.path().join("dst");
+    std::fs::create_dir_all(&src_dir).unwrap();
+    std::fs::write(src_dir.join("a.txt"), b"hello").unwrap();
+
+    let mut cmd = Command::cargo_bin("rsync-rs").unwrap();
+    let src_arg = format!("{}/", src_dir.display());
+    cmd.args(["--local", "--stats", &src_arg, dst_dir.to_str().unwrap()]);
+    cmd.assert()
+        .success()
+        .stdout(predicates::str::contains("files transferred"));
+}
+
+#[test]
+fn config_flag_prints_message() {
+    let dir = tempdir().unwrap();
+    let src_dir = dir.path().join("src");
+    let dst_dir = dir.path().join("dst");
+    std::fs::create_dir_all(&src_dir).unwrap();
+    let cfg = dir.path().join("config");
+    std::fs::write(&cfg, b"cfg").unwrap();
+
+    let mut cmd = Command::cargo_bin("rsync-rs").unwrap();
+    let src_arg = format!("{}/", src_dir.display());
+    cmd.args([
+        "--local",
+        "--config",
+        cfg.to_str().unwrap(),
+        &src_arg,
+        dst_dir.to_str().unwrap(),
+    ]);
+    cmd.assert()
+        .success()
+        .stdout(predicates::str::contains("using config file"));
+}
+
+#[test]
+fn client_rejects_port_without_daemon() {
+    Command::cargo_bin("rsync-rs")
+        .unwrap()
+        .args(["--port", "1234"])
+        .assert()
+        .failure();
+}
+
+#[test]
+fn invalid_compress_level_fails() {
+    Command::cargo_bin("rsync-rs")
+        .unwrap()
+        .args(["--compress-level", "foo"])
+        .assert()
+        .failure();
 }

--- a/tests/golden/cli_parity/compress-level.sh
+++ b/tests/golden/cli_parity/compress-level.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+RSYNC_RS="$ROOT/target/debug/rsync-rs"
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+mkdir -p "$TMP/src" "$TMP/rsync_dst" "$TMP/rsync_rs_dst"
+
+echo data > "$TMP/src/a.txt"
+
+rsync_output=$(rsync --quiet --recursive --compress-level=1 "$TMP/src/" "$TMP/rsync_dst" 2>&1)
+rsync_status=$?
+
+rsync_rs_raw=$("$RSYNC_RS" --local --recursive --compress-level=1 "$TMP/src/" "$TMP/rsync_rs_dst" 2>&1)
+rsync_rs_status=$?
+rsync_rs_output=$(echo "$rsync_rs_raw" | grep -v 'recursive mode enabled' || true)
+
+if [ "$rsync_status" -ne "$rsync_rs_status" ]; then
+  echo "Exit codes differ: rsync=$rsync_status rsync-rs=$rsync_rs_status" >&2
+  exit 1
+fi
+
+if [ "$rsync_output" != "$rsync_rs_output" ]; then
+  echo "Outputs differ" >&2
+  diff -u <(printf "%s" "$rsync_output") <(printf "%s" "$rsync_rs_output") >&2 || true
+  exit 1
+fi
+
+if ! diff -r "$TMP/rsync_dst" "$TMP/rsync_rs_dst" >/dev/null; then
+  echo "Directory trees differ" >&2
+  diff -r "$TMP/rsync_dst" "$TMP/rsync_rs_dst" >&2 || true
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- add tests for verbose, quiet, archive, dry-run, checksum, stats, config, and port flags
- introduce golden parity test for `--compress-level`
- document test coverage in the feature matrix

## Testing
- `cargo test`
- `make test-golden`


------
https://chatgpt.com/codex/tasks/task_e_68b0c221c34c8323adb606e0c3e023fc