### PR TITLE
ci: enforce coverage thresholds and expand checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,12 @@ jobs:
           - os: ubuntu-latest
             target: aarch64-unknown-linux-gnu
             use-cross: true
+          - os: ubuntu-latest
+            target: armv7-unknown-linux-gnueabihf
+            use-cross: true
+          - os: ubuntu-latest
+            target: x86_64-unknown-freebsd
+            use-cross: true
           - os: macos-latest
             target: x86_64-apple-darwin
             use-cross: false
@@ -65,27 +71,24 @@ jobs:
           else
             cargo test --all --target ${{ matrix.target }}
           fi
-      - name: Install cargo-tarpaulin
+      - name: Install cargo-llvm-cov
         if: matrix.os == 'ubuntu-latest' && matrix.use-cross == false
-        run: cargo install cargo-tarpaulin --locked
+        run: cargo install cargo-llvm-cov --locked
       - name: Coverage
         if: matrix.os == 'ubuntu-latest' && matrix.use-cross == false
-        run: cargo tarpaulin --out Xml --output-dir coverage
+        run: cargo llvm-cov --all-features --workspace --fail-under-lines 80 --fail-under-functions 80 --lcov --output-path lcov.info
       - name: Upload coverage report
         if: matrix.os == 'ubuntu-latest' && matrix.use-cross == false
         uses: actions/upload-artifact@v4
         with:
           name: coverage-${{ matrix.target }}
-          path: coverage
+          path: lcov.info
       - name: Golden parity tests
         if: matrix.use-cross == false && matrix.os != 'windows-latest'
         run: make test-golden
       - name: Interop tests
         if: matrix.os == 'ubuntu-latest' && matrix.use-cross == false
         run: bash scripts/interop.sh
-      - name: Interop matrix tests
-        if: matrix.os == 'ubuntu-latest' && matrix.use-cross == false && env.INTEROP_MATRIX == '1'
-        run: bash tests/interop/run_matrix.sh
       - name: Fuzz smoke test
         if: matrix.os == 'ubuntu-latest' && matrix.use-cross == false
         run: |
@@ -104,6 +107,12 @@ jobs:
             use-cross: false
           - os: ubuntu-latest
             target: aarch64-unknown-linux-gnu
+            use-cross: true
+          - os: ubuntu-latest
+            target: armv7-unknown-linux-gnueabihf
+            use-cross: true
+          - os: ubuntu-latest
+            target: x86_64-unknown-freebsd
             use-cross: true
           - os: macos-latest
             target: x86_64-apple-darwin
@@ -132,8 +141,7 @@ jobs:
           name: rsync-rs-${{ matrix.target }}
           path: target/${{ matrix.target }}/release/rsync-rs
 
-  nightly-fuzz:
-    if: github.event_name == 'schedule'
+  fuzz:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -149,6 +157,13 @@ jobs:
             cargo +nightly fuzz run "$target" -- -max_total_time=600
           done
 
+  interop:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run interop matrix
+        run: bash tests/interop/run_matrix.sh
+
   windows-coverage:
     needs: test
     runs-on: windows-latest
@@ -163,7 +178,7 @@ jobs:
       - name: Install cargo-llvm-cov
         run: cargo install cargo-llvm-cov --locked
       - name: Generate coverage report
-        run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
+        run: cargo llvm-cov --all-features --workspace --fail-under-lines 80 --fail-under-functions 80 --lcov --output-path lcov.info
       - name: Upload coverage report
         uses: actions/upload-artifact@v4
         with:

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -9,6 +9,8 @@ have been exercised with `rsync-rs`. For a detailed status matrix see
 | Operating system | Notes |
 |------------------|-------|
 | Linux | primary development and CI platform |
+| Linux (armv7) | cross-compiled in CI |
+| FreeBSD | cross-compiled in CI |
 | macOS | builds and basic local sync verified |
 | Windows | under active development; path and permission handling incomplete |
 

--- a/docs/fuzzing.md
+++ b/docs/fuzzing.md
@@ -4,6 +4,9 @@ This repository includes several fuzz targets under `crates/fuzz`.
 The harnesses are built with [`libFuzzer`](https://llvm.org/docs/LibFuzzer.html)
 via the [`libfuzzer-sys`](https://crates.io/crates/libfuzzer-sys) crate.
 
+Continuous integration runs extended fuzzing sessions for each target on every
+pull request, and the job must pass before merging.
+
 ## Running a fuzzer
 
 1. Install the tooling (once per machine):

--- a/tests/interop/README.md
+++ b/tests/interop/README.md
@@ -8,3 +8,6 @@ filesystem trees for interoperability tests.
   `<client>_<server>_<transport>`.
 - `run_matrix.sh` runs a matrix of rsync 3.2.x client/server combinations over
   both SSH and rsync:// transports. Set `UPDATE=1` to regenerate goldens.
+
+The CI workflow executes `run_matrix.sh` as a required status check to ensure
+interoperability across supported rsync versions.


### PR DESCRIPTION
## Summary
- enforce minimum coverage with cargo-llvm-cov
- add long-running fuzz and interop jobs as required checks
- test additional armv7 and FreeBSD targets
- document platforms and CI requirements

## Testing
- `cargo test`
- `cargo fmt --all --check` *(fails: Diff in src/lib.rs)*
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: derivable impls and io-other-error)*

------
https://chatgpt.com/codex/tasks/task_e_68b0c2266c588323a10585340d2ce0d5