### PR TITLE
docs: record coverage thresholds and future ci tasks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,18 @@ jobs:
           timeout 60s cargo +nightly fuzz run filters_parse_fuzz -- -max_total_time=30
           timeout 60s cargo +nightly fuzz run filters -- -max_total_time=30
 
+      - name: Filter rule edge case tests
+        if: matrix.os == 'ubuntu-latest' && matrix.use-cross == false
+        run: echo "TODO: add filter rule edge case tests once implemented"
+
+      - name: Compression negotiation tests
+        if: matrix.os == 'ubuntu-latest' && matrix.use-cross == false
+        run: echo "TODO: add compression negotiation tests once implemented"
+
+      - name: Daemon authentication tests
+        if: matrix.os == 'ubuntu-latest' && matrix.use-cross == false
+        run: echo "TODO: add daemon authentication tests once implemented"
+
   release:
     if: startsWith(github.ref, 'refs/tags/')
     needs: test

--- a/docs/gaps.md
+++ b/docs/gaps.md
@@ -20,6 +20,6 @@ This document tracks outstanding gaps in `rsync-rs` compared to the reference `r
 - Many CLI options listed in `docs/feature_matrix.md` have no associated tests.
 
 ## Continuous integration deficiencies
-- Coverage is collected on Linux and Windows using `cargo-llvm-cov`, but no thresholds are enforced.
-- Nightly jobs fuzz all targets for longer runs, yet pull requests still rely on brief smoke tests.
-- Remote-to-remote transfers, filter rules, compression negotiation, and daemon authentication lack dedicated CI coverage.
+- Coverage is collected on Linux and Windows using `cargo-llvm-cov`, enforcing 80% line and function thresholds.
+- Pull requests run brief fuzz smoke tests while a nightly job exercises all fuzz targets for extended runs.
+- Remote-to-remote transfers, filter rule edge cases, compression negotiation, and daemon authentication lack dedicated CI coverage.


### PR DESCRIPTION
## Summary
- document coverage thresholds and fuzzing jobs
- add CI placeholders for filter rules, compression negotiation, and daemon auth tests

## Testing
- `cargo test` *(fails: remote_to_remote_pipes_data)*

------
https://chatgpt.com/codex/tasks/task_e_68b0c760cb3483239a865211d4a1616e