### PR TITLE
docs: document coverage thresholds

### DIFF
--- a/docs/gaps.md
+++ b/docs/gaps.md
@@ -20,6 +20,7 @@ This document tracks outstanding gaps in `rsync-rs` compared to the reference `r
 - Many CLI options listed in `docs/feature_matrix.md` have no associated tests.
 
 ## Continuous integration deficiencies
-- Coverage is collected on Linux and Windows using `cargo-llvm-cov`, but no thresholds are enforced.
+- Coverage is collected on Linux and Windows using `cargo-llvm-cov` with `--fail-under-lines 80` and `--fail-under-functions 80` thresholds.
+  Raise these thresholds as the test suite stabilizes.
 - Nightly jobs fuzz all targets for longer runs, yet pull requests still rely on brief smoke tests.
 - Remote-to-remote transfers, filter rules, compression negotiation, and daemon authentication lack dedicated CI coverage.


### PR DESCRIPTION
## Summary
- document current coverage thresholds and note raising them as tests stabilize

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68b0c769a5ac8323b17ae47aaa9fe916