### PR TITLE
Enforce delete parity test and add delete-delay coverage

### DIFF
--- a/docs/feature_matrix.md
+++ b/docs/feature_matrix.md
@@ -39,7 +39,7 @@ This table tracks the implementation status of rsync 3.2.x command-line options.
 | `--delete` | ✅ | ✅ | [tests/golden/cli_parity/delete.sh](../tests/golden/cli_parity/delete.sh) |  |
 | `--delete-after` | ✅ | ✅ | [tests/golden/cli_parity/delete.sh](../tests/golden/cli_parity/delete.sh) |  |
 | `--delete-before` | ✅ | ✅ | [tests/golden/cli_parity/delete.sh](../tests/golden/cli_parity/delete.sh) |  |
-| `--delete-delay` | ✅ | ❌ | — |  |
+| `--delete-delay` | ✅ | ✅ | [tests/golden/cli_parity/delete.sh](../tests/golden/cli_parity/delete.sh) |  |
 | `--delete-during` | ✅ | ✅ | [tests/golden/cli_parity/delete.sh](../tests/golden/cli_parity/delete.sh) |  |
 | `--delete-excluded` | ❌ | — | — |  |
 | `--delete-missing-args` | ❌ | — | — |  |

--- a/tests/golden/cli_parity/delete.sh
+++ b/tests/golden/cli_parity/delete.sh
@@ -27,11 +27,6 @@ run_case() {
   set -e
   rsync_rs_output=$(echo "$rsync_rs_raw" | grep -v 'recursive mode enabled' || true)
 
-  if [ "$rsync_rs_status" -ne 0 ]; then
-    echo "rsync-rs $flag not implemented; skipping parity check" >&2
-    return
-  fi
-
   if [ "$rsync_status" -ne "$rsync_rs_status" ]; then
     echo "Exit codes differ: rsync=$rsync_status rsync-rs=$rsync_rs_status" >&2
     exit 1
@@ -53,5 +48,6 @@ run_case() {
 run_case --delete
 run_case --delete-before
 run_case --delete-after
+run_case --delete-delay
 run_case --delete-during
 run_case --del


### PR DESCRIPTION
## Summary
- Remove skip logic in delete parity script so unimplemented flags cause a failure
- Add rsync baseline for `--delete-delay` alongside existing delete modes
- Document parity support for `--delete-delay` in feature matrix

## Testing
- `cargo test`
- `make test-golden`


------
https://chatgpt.com/codex/tasks/task_e_68b0c759bcac83238c64a035a24e37fa