### PR TITLE
Document CLI option tests and add perms validation

### DIFF
--- a/docs/feature_matrix.md
+++ b/docs/feature_matrix.md
@@ -16,7 +16,7 @@ This table tracks the implementation status of rsync 3.2.x command-line options.
 | `--block-size` | ❌ | — | — |  |
 | `--blocking-io` | ❌ | — | — |  |
 | `--bwlimit` | ❌ | — | — |  |
-| `--checksum` | ✅ | ❌ | — |  |
+| `--checksum` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  |
 | `--checksum-choice` | ❌ | — | — |  |
 | `--checksum-seed` | ❌ | — | — |  |
 | `--chmod` | ❌ | — | — |  |
@@ -24,7 +24,7 @@ This table tracks the implementation status of rsync 3.2.x command-line options.
 | `--compare-dest` | ❌ | — | — |  |
 | `--compress` | ✅ | ✅ | [tests/golden/cli_parity/compression.sh](../tests/golden/cli_parity/compression.sh) |  |
 | `--compress-choice` | ❌ | — | — |  |
-| `--compress-level` | ✅ | ❌ | — |  |
+| `--compress-level` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  |
 | `--contimeout` | ❌ | — | — |  |
 | `--copy-as` | ❌ | — | — |  |
 | `--copy-dest` | ❌ | — | — |  |
@@ -45,7 +45,7 @@ This table tracks the implementation status of rsync 3.2.x command-line options.
 | `--delete-missing-args` | ❌ | — | — |  |
 | `--devices` | ✅ | ❌ | [tests/local_sync_tree.rs](../tests/local_sync_tree.rs) |  |
 | `--dirs` | ❌ | — | — |  |
-| `--dry-run` | ✅ | ❌ | — |  |
+| `--dry-run` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  |
 | `--early-input` | ❌ | — | — |  |
 | `--exclude` | ✅ | ❌ | — |  |
 | `--exclude-from` | ✅ | ❌ | — |  |
@@ -105,7 +105,7 @@ This table tracks the implementation status of rsync 3.2.x command-line options.
 | `--partial` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  |
 | `--partial-dir` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  |
 | `--password-file` | ❌ | — | — |  |
-| `--perms` | ✅ | ❌ | — |  |
+| `--perms` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  |
 | `--port` | ❌ | — | — |  |
 | `--preallocate` | ❌ | — | — |  |
 | `--progress` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  |
@@ -114,7 +114,7 @@ This table tracks the implementation status of rsync 3.2.x command-line options.
 | `--quiet` | ✅ | ✅ | [tests/golden/cli_parity/compression.sh](../tests/golden/cli_parity/compression.sh)<br>[tests/golden/cli_parity/delete.sh](../tests/golden/cli_parity/delete.sh)<br>[tests/golden/cli_parity/selection.sh](../tests/golden/cli_parity/selection.sh) |  |
 | `--read-batch` | ❌ | — | — |  |
 | `--recursive` | ✅ | ✅ | [tests/golden/cli_parity/delete.sh](../tests/golden/cli_parity/delete.sh)<br>[tests/golden/cli_parity/compression.sh](../tests/golden/cli_parity/compression.sh)<br>[tests/golden/cli_parity/selection.sh](../tests/golden/cli_parity/selection.sh) |  |
-| `--relative` | ✅ | ❌ | — |  |
+| `--relative` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  |
 | `--remote-option` | ❌ | — | — |  |
 | `--remove-source-files` | ❌ | — | — |  |
 | `--rsh` | ❌ | — | — |  |
@@ -126,7 +126,7 @@ This table tracks the implementation status of rsync 3.2.x command-line options.
 | `--sockopts` | ❌ | — | — |  |
 | `--sparse` | ✅ | ❌ | — |  |
 | `--specials` | ✅ | ❌ | — |  |
-| `--stats` | ✅ | ❌ | — |  |
+| `--stats` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  |
 | `--stderr` | ❌ | — | — |  |
 | `--stop-after` | ❌ | — | — |  |
 | `--stop-at` | ❌ | — | — |  |
@@ -138,7 +138,7 @@ This table tracks the implementation status of rsync 3.2.x command-line options.
 | `--trust-sender` | ❌ | — | — |  |
 | `--update` | ❌ | — | — |  |
 | `--usermap` | ❌ | — | — |  |
-| `--verbose` | ❌ | — | — |  |
+| `--verbose` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  |
 | `--version` | ❌ | — | — |  |
 | `--whole-file` | ❌ | — | — |  |
 | `--write-batch` | ❌ | — | — |  |

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -3,7 +3,7 @@ use filetime::{set_file_mtime, FileTime};
 #[cfg(unix)]
 use nix::unistd::{chown, Gid, Uid};
 #[cfg(unix)]
-use std::os::unix::fs::MetadataExt;
+use std::os::unix::fs::{MetadataExt, PermissionsExt};
 use tempfile::tempdir;
 
 #[test]
@@ -274,6 +274,30 @@ fn checksum_forces_transfer_cli() {
         .assert()
         .success();
     assert_eq!(std::fs::read(&dst_file).unwrap(), b"aaaa");
+}
+
+#[cfg(unix)]
+#[test]
+fn perms_flag_preserves_permissions() {
+    use std::fs;
+    let dir = tempdir().unwrap();
+    let src_dir = dir.path().join("src");
+    let dst_dir = dir.path().join("dst");
+    fs::create_dir_all(&src_dir).unwrap();
+    let file = src_dir.join("a.txt");
+    fs::write(&file, b"hi").unwrap();
+    fs::set_permissions(&file, fs::Permissions::from_mode(0o741)).unwrap();
+
+    let mut cmd = Command::cargo_bin("rsync-rs").unwrap();
+    let src_arg = format!("{}/", src_dir.display());
+    cmd.args(["--local", "--perms", &src_arg, dst_dir.to_str().unwrap()]);
+    cmd.assert().success();
+
+    let mode = fs::metadata(dst_dir.join("a.txt"))
+        .unwrap()
+        .permissions()
+        .mode();
+    assert_eq!(mode & 0o777, 0o741);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add CLI integration test ensuring `--perms` preserves file modes
- document support for several CLI flags and link to tests

## Testing
- `cargo test --test cli`
- `cargo test` *(fails: remote_to_remote_pipes_data)*

------
https://chatgpt.com/codex/tasks/task_e_68b0c75574e483238ed2d7f936b70426