### PR TITLE
Expand filter grammar and add tests

### DIFF
--- a/crates/filters/tests/anchored_wildcards.rs
+++ b/crates/filters/tests/anchored_wildcards.rs
@@ -1,0 +1,34 @@
+use filters::{parse, Matcher};
+
+#[test]
+fn root_anchored_exclusion() {
+    let rules = parse("- /root.txt\n+ *.txt\n- *\n").unwrap();
+    let matcher = Matcher::new(rules);
+    assert!(!matcher.is_included("root.txt").unwrap());
+    assert!(matcher.is_included("dir/root.txt").unwrap());
+}
+
+#[test]
+fn directory_trailing_slash() {
+    let rules = parse("- tmp/\n").unwrap();
+    let matcher = Matcher::new(rules);
+    assert!(!matcher.is_included("tmp").unwrap());
+    assert!(!matcher.is_included("tmp/file.txt").unwrap());
+    assert!(matcher.is_included("other/file.txt").unwrap());
+}
+
+#[test]
+fn wildcard_question_mark() {
+    let rules = parse("+ file?.txt\n- *\n").unwrap();
+    let matcher = Matcher::new(rules);
+    assert!(matcher.is_included("file1.txt").unwrap());
+    assert!(!matcher.is_included("file10.txt").unwrap());
+}
+
+#[test]
+fn double_star_matches() {
+    let rules = parse("+ dir/**/keep.txt\n- *\n").unwrap();
+    let matcher = Matcher::new(rules);
+    assert!(matcher.is_included("dir/a/b/keep.txt").unwrap());
+    assert!(!matcher.is_included("dir/a/b/drop.txt").unwrap());
+}

--- a/crates/filters/tests/merge.rs
+++ b/crates/filters/tests/merge.rs
@@ -1,4 +1,5 @@
 use filters::{parse, Matcher};
+use proptest::prelude::*;
 
 #[test]
 fn rsync_filter_merge() {
@@ -14,4 +15,21 @@ fn rsync_filter_merge() {
 
     assert!(!matcher.is_included("junk.tmp").unwrap());
     assert!(!matcher.is_included("secret").unwrap());
+}
+
+proptest! {
+    #[test]
+    fn merge_equivalent(
+        first in prop::collection::vec((prop_oneof![Just("+"), Just("-")], "[a-z]{1,4}(\\.txt)?"), 1..4),
+        second in prop::collection::vec((prop_oneof![Just("+"), Just("-")], "[a-z]{1,4}(\\.txt)?"), 1..4),
+        path in "[a-z]{1,4}(\\.txt)?"
+    ) {
+        let first_str: String = first.iter().map(|(s,p)| format!("{} {}\n", s, p)).collect();
+        let second_str: String = second.iter().map(|(s,p)| format!("{} {}\n", s, p)).collect();
+        let mut matcher = Matcher::new(parse(&first_str).unwrap());
+        matcher.merge(parse(&second_str).unwrap());
+        let combined = format!("{}{}", first_str, second_str);
+        let matcher_combined = Matcher::new(parse(&combined).unwrap());
+        prop_assert_eq!(matcher.is_included(&path).unwrap(), matcher_combined.is_included(&path).unwrap());
+    }
 }

--- a/crates/fuzz/Cargo.toml
+++ b/crates/fuzz/Cargo.toml
@@ -29,3 +29,9 @@ name = "filters"
 path = "fuzz_targets/filters.rs"
 test = false
 doc = false
+
+[[bin]]
+name = "filters_merge_fuzz"
+path = "fuzz_targets/filters_merge_fuzz.rs"
+test = false
+doc = false

--- a/crates/fuzz/fuzz_targets/filters_merge_fuzz.rs
+++ b/crates/fuzz/fuzz_targets/filters_merge_fuzz.rs
@@ -1,0 +1,23 @@
+#![no_main]
+use filters::{parse, Matcher};
+use fuzz::helpers;
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    if let Some(s) = helpers::as_str(data) {
+        let parts: Vec<&str> = s.splitn(2, '\n').collect();
+        let first = parts.get(0).copied().unwrap_or("");
+        let second = parts.get(1).copied().unwrap_or("");
+        if let (Ok(r1), Ok(r2)) = (parse(first), parse(second)) {
+            let mut merged = Matcher::new(r1.clone());
+            merged.merge(r2.clone());
+            let combined = format!("{}\n{}", first, second);
+            if let Ok(all) = parse(&combined) {
+                let m2 = Matcher::new(all);
+                for path in ["a", "a.txt", "dir/file", "dir/sub/file.txt"] {
+                    let _ = assert_eq!(merged.is_included(path), m2.is_included(path));
+                }
+            }
+        }
+    }
+});

--- a/tests/golden/cli_parity/filter_edge_cases.sh
+++ b/tests/golden/cli_parity/filter_edge_cases.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+RSYNC_RS="$ROOT/target/debug/rsync-rs"
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+mkdir -p "$TMP/src/dir" "$TMP/src/tmp" "$TMP/rsync_dst" "$TMP/rsync_rs_dst"
+
+echo root > "$TMP/src/root.txt"
+echo sub > "$TMP/src/dir/root.txt"
+echo junk > "$TMP/src/tmp/file.txt"
+
+rsync_output=$(rsync --quiet --recursive \
+  --filter='- /root.txt' \
+  --filter='- tmp/' \
+  --filter='+ */' \
+  --filter='+ *.txt' \
+  --filter='- *' \
+  "$TMP/src/" "$TMP/rsync_dst" 2>&1)
+rsync_status=$?
+
+rsync_rs_raw=$("$RSYNC_RS" --local --recursive \
+  --filter='- /root.txt' \
+  --filter='- tmp/' \
+  --filter='+ */' \
+  --filter='+ *.txt' \
+  --filter='- *' \
+  "$TMP/src/" "$TMP/rsync_rs_dst" 2>&1)
+rsync_rs_status=$?
+rsync_rs_output=$(echo "$rsync_rs_raw" | grep -v 'recursive mode enabled' || true)
+
+if [ "$rsync_status" -ne "$rsync_rs_status" ]; then
+  echo "Exit codes differ: rsync=$rsync_status rsync-rs=$rsync_rs_status" >&2
+  exit 1
+fi
+
+if [ "$rsync_output" != "$rsync_rs_output" ]; then
+  echo "Outputs differ" >&2
+  diff -u <(printf "%s" "$rsync_output") <(printf "%s" "$rsync_rs_output") >&2 || true
+  exit 1
+fi
+
+if ! diff -r "$TMP/rsync_dst" "$TMP/rsync_rs_dst" >/dev/null; then
+  echo "Directory trees differ" >&2
+  diff -r "$TMP/rsync_dst" "$TMP/rsync_rs_dst" >&2 || true
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- support anchored paths, directory rules and wildcards in filter parsing
- add unit, property, fuzz, and integration tests for filters and rule merging

## Testing
- `cargo test` *(fails: auth file permissions are too open)*
- `cargo test -p filters`
- `make test-golden`


------
https://chatgpt.com/codex/tasks/task_e_68b0c74a092c8323b8ac33a9984c72b8