### PR TITLE
Fix mode type conversion in metadata apply

### DIFF
--- a/crates/meta/src/lib.rs
+++ b/crates/meta/src/lib.rs
@@ -1,5 +1,6 @@
 use std::io;
 use std::path::Path;
+use std::convert::TryInto;
 
 use filetime::{self, FileTime};
 use nix::sys::stat::{self, FchmodatFlags, Mode};
@@ -103,7 +104,7 @@ impl Metadata {
         )
         .map_err(nix_to_io)?;
 
-        let mode = Mode::from_bits_truncate(self.mode);
+        let mode = Mode::from_bits_truncate(self.mode.try_into().unwrap());
         stat::fchmodat(None, path, mode, FchmodatFlags::NoFollowSymlink).map_err(nix_to_io)?;
 
         filetime::set_file_mtime(path, self.mtime)?;


### PR DESCRIPTION
## Summary
- Fix `Mode::from_bits_truncate` usage by converting stored mode to platform-specific bits

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68b0cb063b0c8323b6bf3ed172d87ad9