### PR TITLE
Convert file mode to mode_t in metadata apply

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -810,6 +810,7 @@ name = "meta"
 version = "0.1.0"
 dependencies = [
  "filetime",
+ "libc",
  "nix",
  "posix-acl",
  "tempfile",

--- a/crates/meta/Cargo.toml
+++ b/crates/meta/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 nix = { version = "0.27", features = ["fs", "user"] }
 filetime = "0.2"
+libc = "0.2"
 
 [dependencies.xattr]
 version = "1.5"

--- a/crates/meta/src/lib.rs
+++ b/crates/meta/src/lib.rs
@@ -103,7 +103,11 @@ impl Metadata {
         )
         .map_err(nix_to_io)?;
 
-        let mode = Mode::from_bits_truncate(self.mode);
+        let mode_t: libc::mode_t = self
+            .mode
+            .try_into()
+            .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "mode does not fit into mode_t"))?;
+        let mode = Mode::from_bits_truncate(mode_t);
         stat::fchmodat(None, path, mode, FchmodatFlags::NoFollowSymlink).map_err(nix_to_io)?;
 
         filetime::set_file_mtime(path, self.mtime)?;


### PR DESCRIPTION
## Summary
- convert stored mode to `libc::mode_t` with fallible conversion before applying permissions
- add `libc` dependency for metadata crate

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68b0cbaefa048323acc68e46f5cd0b25