### PR TITLE
Avoid unused Options warnings in meta crate

### DIFF
--- a/crates/meta/src/lib.rs
+++ b/crates/meta/src/lib.rs
@@ -54,7 +54,7 @@ pub struct Metadata {
 
 impl Metadata {
     /// Read metadata from `path` using `opts`.
-    pub fn from_path(path: &Path, opts: Options) -> io::Result<Self> {
+    pub fn from_path(path: &Path, _opts: Options) -> io::Result<Self> {
         let st = stat::stat(path).map_err(nix_to_io)?;
         let uid = st.st_uid;
         let gid = st.st_gid;
@@ -62,7 +62,7 @@ impl Metadata {
         let mtime = FileTime::from_unix_time(st.st_mtime, st.st_mtime_nsec as u32);
 
         #[cfg(feature = "xattr")]
-        let xattrs = if opts.xattrs {
+        let xattrs = if _opts.xattrs {
             let mut attrs = Vec::new();
             for attr in xattr::list(path)? {
                 if let Some(value) = xattr::get(path, &attr)? {
@@ -75,7 +75,7 @@ impl Metadata {
         };
 
         #[cfg(feature = "acl")]
-        let acl = if opts.acl {
+        let acl = if _opts.acl {
             let acl = posix_acl::PosixACL::read_acl(path).map_err(acl_to_io)?;
             acl.entries()
         } else {
@@ -95,7 +95,7 @@ impl Metadata {
     }
 
     /// Apply metadata to `path` using `opts`.
-    pub fn apply(&self, path: &Path, opts: Options) -> io::Result<()> {
+    pub fn apply(&self, path: &Path, _opts: Options) -> io::Result<()> {
         unistd::chown(
             path,
             Some(Uid::from_raw(self.uid)),
@@ -109,14 +109,14 @@ impl Metadata {
         filetime::set_file_mtime(path, self.mtime)?;
 
         #[cfg(feature = "xattr")]
-        if opts.xattrs {
+        if _opts.xattrs {
             for (name, value) in &self.xattrs {
                 xattr::set(path, name, value)?;
             }
         }
 
         #[cfg(feature = "acl")]
-        if opts.acl {
+        if _opts.acl {
             let mut acl = posix_acl::PosixACL::empty();
             for entry in &self.acl {
                 acl.set(entry.qual, entry.perm);


### PR DESCRIPTION
## Summary
- rename `opts` parameters in metadata helpers to `_opts` so builds without `xattr` or `acl` features compile cleanly

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68b0cbafa5e88323be68ae940599784e