### PR TITLE
docs: document handshake and remote transfer gaps

### DIFF
--- a/docs/gaps.md
+++ b/docs/gaps.md
@@ -3,6 +3,9 @@
 This document tracks outstanding gaps in `rsync-rs` compared to the reference `rsync` implementation. Update this file as features are implemented.
 
 ## Missing rsync behaviors
+- The `--server` handshake is not implemented, leaving server-mode negotiation incomplete; see the `--protocol` entry in `docs/feature_matrix.md`.
+- Remote shell (`--rsh`) handling is incomplete (see the `--rsh` row in `docs/feature_matrix.md`).
+- Daemon mode achieves only partial feature parity; `--password-file` and `--secrets-file` remain incomplete (see `docs/feature_matrix.md`).
 - Filter rules are incomplete and do not yet match `rsync`'s full include/exclude syntax.
 - Compression negotiation between peers is unimplemented.
 - Many command-line options remain absent or lack parity; see `docs/feature_matrix.md` for the full matrix.
@@ -15,7 +18,8 @@ This document tracks outstanding gaps in `rsync-rs` compared to the reference `r
 
 ## Test coverage gaps
 - `tests/golden/cli_parity/delete.sh` skips parity checks for deletion flags that are unimplemented or fail, which can hide gaps in deletion behavior.
-- `tests/remote_remote.rs` exercises remote-to-remote transfers but only covers a basic pipe scenario.
+- `tests/remote_remote.rs` exercises remote-to-remote transfers but only covers a basic pipe scenario; broader coverage for `--rsh` and related flows is missing (see `docs/feature_matrix.md` `--rsh`).
+- Filter and compression negotiation lack dedicated tests; see `docs/feature_matrix.md` entries for `--filter`, `--compress`, and `--compress-level`.
 - Many CLI options listed in `docs/feature_matrix.md` have no associated tests.
 
 ## Continuous integration deficiencies


### PR DESCRIPTION
## Summary
- note missing `--server` handshake and incomplete `--rsh` support
- highlight partial daemon feature parity with links to feature matrix
- call out lacking remote-to-remote scenarios and filter/compression negotiation tests

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68b0cc601e388323819adbba771fd962