### PR TITLE
Add integration test scripts and CI hooks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,15 +97,15 @@ jobs:
 
       - name: Filter rule edge case tests
         if: matrix.os == 'ubuntu-latest' && matrix.use-cross == false
-        run: echo "TODO: add filter rule edge case tests once implemented"
+        run: bash tests/filter_rule_precedence.sh
 
       - name: Compression negotiation tests
         if: matrix.os == 'ubuntu-latest' && matrix.use-cross == false
-        run: echo "TODO: add compression negotiation tests once implemented"
+        run: bash tests/compression_negotiation.sh
 
       - name: Daemon authentication tests
         if: matrix.os == 'ubuntu-latest' && matrix.use-cross == false
-        run: echo "TODO: add daemon authentication tests once implemented"
+        run: bash tests/daemon_auth.sh
 
   release:
     if: startsWith(github.ref, 'refs/tags/')

--- a/tests/compression_negotiation.sh
+++ b/tests/compression_negotiation.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run compression codec negotiation tests from the compress crate
+cargo test -p compress --test codecs -- negotiation_helper_picks_common_codec

--- a/tests/daemon_auth.sh
+++ b/tests/daemon_auth.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Execute daemon authentication tests individually for clarity
+cargo test --test daemon -- --exact daemon_rejects_invalid_token
+cargo test --test daemon -- --exact daemon_rejects_unauthorized_module
+cargo test --test daemon -- --exact daemon_accepts_authorized_client

--- a/tests/filter_rule_precedence.sh
+++ b/tests/filter_rule_precedence.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+RSYNC_RS="$ROOT/target/debug/rsync-rs"
+
+# Ensure binary is built
+cargo build --quiet --bin rsync-rs
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+mkdir -p "$TMP/src/keep/sub" "$TMP/src/keep/tmp" "$TMP/src/skip" "$TMP/rsync_dst" "$TMP/rsync_rs_dst"
+
+# Populate source tree
+
+echo keep > "$TMP/src/keep/file.txt"
+echo sub > "$TMP/src/keep/sub/file.md"
+echo tmp > "$TMP/src/keep/tmp/file.tmp"
+echo skip > "$TMP/src/skip/file.txt"
+echo root > "$TMP/src/root.tmp"
+
+# Run reference rsync
+rsync_output=$(rsync --quiet --recursive \
+  --filter='- *.tmp' \
+  --filter='+ keep/tmp/file.tmp' \
+  --filter='- skip/' \
+  --filter='+ keep/***' \
+  --filter='+ *.md' \
+  --filter='- *' \
+  "$TMP/src/" "$TMP/rsync_dst" 2>&1)
+rsync_status=$?
+
+# Run rsync-rs
+rsync_rs_raw=$("$RSYNC_RS" --local --recursive \
+  --filter='- *.tmp' \
+  --filter='+ keep/tmp/file.tmp' \
+  --filter='- skip/' \
+  --filter='+ keep/***' \
+  --filter='+ *.md' \
+  --filter='- *' \
+  "$TMP/src/" "$TMP/rsync_rs_dst" 2>&1)
+rsync_rs_status=$?
+rsync_rs_output=$(echo "$rsync_rs_raw" | grep -v -e 'recursive mode enabled' || true)
+
+# Compare exit codes
+if [ "$rsync_status" -ne "$rsync_rs_status" ]; then
+  echo "Exit codes differ: rsync=$rsync_status rsync-rs=$rsync_rs_status" >&2
+  exit 1
+fi
+
+# Compare outputs
+if [ "$rsync_output" != "$rsync_rs_output" ]; then
+  echo "Outputs differ" >&2
+  diff -u <(printf "%s" "$rsync_output") <(printf "%s" "$rsync_rs_output") >&2 || true
+  exit 1
+fi
+
+# Compare directory trees
+if ! diff -r "$TMP/rsync_dst" "$TMP/rsync_rs_dst" >/dev/null; then
+  echo "Directory trees differ" >&2
+  diff -r "$TMP/rsync_dst" "$TMP/rsync_rs_dst" >&2 || true
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- add shell tests for complex filter precedence, codec negotiation, and daemon authentication
- run these test scripts during CI

## Testing
- `bash tests/filter_rule_precedence.sh`
- `bash tests/compression_negotiation.sh`
- `bash tests/daemon_auth.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b0cc4910fc8323b90dc2f15511261a