### PR TITLE
test: add remote remote resilience tests

### DIFF
--- a/tests/interop/remote_remote_tests.rs
+++ b/tests/interop/remote_remote_tests.rs
@@ -1,1 +1,3 @@
-include!("../remote_remote.rs");
+// Reuse the core remote-remote tests in the interop test suite so CI exercises
+// them against real transports as well.
+include!(concat!(env!("CARGO_MANIFEST_DIR"), "/tests/remote_remote.rs"));

--- a/tests/remote_remote.rs
+++ b/tests/remote_remote.rs
@@ -1,7 +1,9 @@
 use assert_cmd::Command;
 use std::fs;
+use std::io::{Read, Write};
 use tempfile::tempdir;
 use transport::ssh::SshStdioTransport;
+use serial_test::serial;
 
 #[test]
 fn remote_to_remote_pipes_data() {
@@ -82,9 +84,137 @@ fn remote_to_remote_reports_errors() {
 }
 
 #[test]
+#[serial]
 fn remote_pair_unresolvable_host_fails() {
     let mut cmd = Command::cargo_bin("rsync-rs").unwrap();
     // Using an unresolvable host should fail quickly
     cmd.args(["nosuchhost.invalid:/tmp/src", "nosuchhost.invalid:/tmp/dst"]);
     cmd.assert().failure();
+}
+
+#[test]
+fn remote_to_remote_different_block_sizes() {
+    let dir = tempdir().unwrap();
+    let src_file = dir.path().join("src.bin");
+    let dst_file = dir.path().join("dst.bin");
+    let data = vec![0xA5u8; 64 * 1024 + 123];
+    fs::write(&src_file, &data).unwrap();
+
+    let src_session =
+        SshStdioTransport::spawn("sh", ["-c", &format!("cat {}", src_file.display())]).unwrap();
+    let dst_session =
+        SshStdioTransport::spawn("sh", ["-c", &format!("cat > {}", dst_file.display())]).unwrap();
+    let (mut src_reader, _) = src_session.into_inner();
+    let (_, mut dst_writer) = dst_session.into_inner();
+
+    let mut read_buf = vec![0u8; 1024];
+    let mut write_buf = Vec::with_capacity(4096);
+    loop {
+        let n = src_reader.read(&mut read_buf).unwrap();
+        if n == 0 {
+            if !write_buf.is_empty() {
+                dst_writer.write_all(&write_buf).unwrap();
+            }
+            break;
+        }
+        write_buf.extend_from_slice(&read_buf[..n]);
+        if write_buf.len() >= 4096 {
+            dst_writer.write_all(&write_buf).unwrap();
+            write_buf.clear();
+        }
+    }
+    drop(dst_writer);
+    drop(src_reader);
+    std::thread::sleep(std::time::Duration::from_millis(50));
+
+    let out = fs::read(dst_file).unwrap();
+    assert_eq!(out, data);
+}
+
+#[test]
+fn remote_to_remote_partial_and_resume() {
+    let dir = tempdir().unwrap();
+    let src_file = dir.path().join("src.txt");
+    let dst_file = dir.path().join("dst.txt");
+    fs::write(&src_file, b"hello world").unwrap();
+
+    // Initial partial transfer of first 5 bytes
+    let src_session = SshStdioTransport::spawn(
+        "sh",
+        [
+            "-c",
+            &format!("head -c 5 {} 2>/dev/null", src_file.display()),
+        ],
+    )
+    .unwrap();
+    let dst_session =
+        SshStdioTransport::spawn("sh", ["-c", &format!("cat > {}", dst_file.display())]).unwrap();
+    let (mut src_reader, _) = src_session.into_inner();
+    let (_, mut dst_writer) = dst_session.into_inner();
+    std::io::copy(&mut src_reader, &mut dst_writer).unwrap();
+    drop(dst_writer);
+    drop(src_reader);
+    std::thread::sleep(std::time::Duration::from_millis(50));
+
+    let partial = fs::read(&dst_file).unwrap();
+    assert_eq!(partial, b"hello");
+
+    // Resume transfer with remaining bytes
+    let src_session = SshStdioTransport::spawn(
+        "sh",
+        [
+            "-c",
+            &format!("tail -c +6 {} 2>/dev/null", src_file.display()),
+        ],
+    )
+    .unwrap();
+    let dst_session =
+        SshStdioTransport::spawn("sh", ["-c", &format!("cat >> {}", dst_file.display())]).unwrap();
+    let (mut src_reader, _) = src_session.into_inner();
+    let (_, mut dst_writer) = dst_session.into_inner();
+    std::io::copy(&mut src_reader, &mut dst_writer).unwrap();
+    drop(dst_writer);
+    drop(src_reader);
+    std::thread::sleep(std::time::Duration::from_millis(50));
+
+    let out = fs::read(&dst_file).unwrap();
+    assert_eq!(out, b"hello world");
+}
+
+#[test]
+fn remote_to_remote_failure_and_reconnect() {
+    let dir = tempdir().unwrap();
+    let src_file = dir.path().join("src.txt");
+    let dst_file = dir.path().join("dst.txt");
+    fs::write(&src_file, b"network glitch test").unwrap();
+
+    // Initial transfer fails because destination immediately closes
+    let src_session =
+        SshStdioTransport::spawn("sh", ["-c", &format!("cat {}", src_file.display())]).unwrap();
+    let dst_session =
+        SshStdioTransport::spawn("sh", ["-c", "exec 0<&-; sleep 1"]).unwrap();
+    let (mut src_reader, _) = src_session.into_inner();
+    let (_, mut dst_writer) = dst_session.into_inner();
+    let result = std::io::copy(&mut src_reader, &mut dst_writer);
+    assert!(result.is_err());
+    drop(dst_writer);
+    drop(src_reader);
+    std::thread::sleep(std::time::Duration::from_millis(50));
+    assert!(!dst_file.exists());
+
+    // Reconnect and complete transfer
+    let src_session =
+        SshStdioTransport::spawn("sh", ["-c", &format!("cat {}", src_file.display())]).unwrap();
+    let dst_session =
+        SshStdioTransport::spawn("sh", ["-c", &format!("cat > {}", dst_file.display())]).unwrap();
+    let (mut src_reader, _) = src_session.into_inner();
+    let (_, mut dst_writer) = dst_session.into_inner();
+    std::io::copy(&mut src_reader, &mut dst_writer).unwrap();
+    drop(dst_writer);
+    drop(src_reader);
+    std::thread::sleep(std::time::Duration::from_millis(50));
+
+    let out_src = fs::read(&src_file).unwrap();
+    let out_dst = fs::read(&dst_file).unwrap();
+    assert_eq!(out_src, out_dst);
 }


### PR DESCRIPTION
## Summary
- extend remote-remote coverage for varied block sizes, resume support, and reconnect after failure
- ensure interop suite includes these remote-remote scenarios

## Testing
- `cargo test --test remote_remote`

------
https://chatgpt.com/codex/tasks/task_e_68b0cc58231c8323b23fb9ff105c41d3