### PR TITLE
docs: expand feature matrix for remote options

### DIFF
--- a/docs/feature_matrix.md
+++ b/docs/feature_matrix.md
@@ -2,146 +2,148 @@
 
 This table tracks the implementation status of rsync 3.2.x command-line options.
 
-| Option | Supported | Parity | Tests | Notes |
-| --- | --- | --- | --- | --- |
-| `--8-bit-output` | ❌ | — | — |  |
-| `--acls` | ❌ | — | — |  |
-| `--address` | ❌ | — | — |  |
-| `--append` | ❌ | — | — |  |
-| `--append-verify` | ❌ | — | — |  |
-| `--archive` | ✅ | ❌ | [tests/interop/run_matrix.sh](../tests/interop/run_matrix.sh) |  |
-| `--atimes` | ❌ | — | — |  |
-| `--backup` | ❌ | — | — |  |
-| `--backup-dir` | ❌ | — | — |  |
-| `--block-size` | ❌ | — | — |  |
-| `--blocking-io` | ❌ | — | — |  |
-| `--bwlimit` | ❌ | — | — |  |
-| `--checksum` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  |
-| `--checksum-choice` | ❌ | — | — |  |
-| `--checksum-seed` | ❌ | — | — |  |
-| `--chmod` | ❌ | — | — |  |
-| `--chown` | ❌ | — | — |  |
-| `--compare-dest` | ❌ | — | — |  |
-| `--compress` | ✅ | ✅ | [tests/golden/cli_parity/compression.sh](../tests/golden/cli_parity/compression.sh) |  |
-| `--compress-choice` | ❌ | — | — |  |
-| `--compress-level` | ✅ | ❌ | [tests/golden/cli_parity/compress-level.sh](../tests/golden/cli_parity/compress-level.sh) |  |
-| `--contimeout` | ❌ | — | — |  |
-| `--copy-as` | ❌ | — | — |  |
-| `--copy-dest` | ❌ | — | — |  |
-| `--copy-devices` | ❌ | — | — |  |
-| `--copy-dirlinks` | ❌ | — | — |  |
-| `--copy-links` | ❌ | — | — |  |
-| `--copy-unsafe-links` | ❌ | — | — |  |
-| `--crtimes` | ❌ | — | — |  |
-| `--cvs-exclude` | ❌ | — | — |  |
-| `--debug` | ❌ | — | — |  |
-| `--delay-updates` | ❌ | — | — |  |
-| `--delete` | ✅ | ✅ | [tests/golden/cli_parity/delete.sh](../tests/golden/cli_parity/delete.sh) |  |
-| `--delete-after` | ✅ | ✅ | [tests/golden/cli_parity/delete.sh](../tests/golden/cli_parity/delete.sh) |  |
-| `--delete-before` | ✅ | ✅ | [tests/golden/cli_parity/delete.sh](../tests/golden/cli_parity/delete.sh) |  |
-| `--delete-delay` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  |
-| `--delete-during` | ✅ | ✅ | [tests/golden/cli_parity/delete.sh](../tests/golden/cli_parity/delete.sh) |  |
-| `--delete-excluded` | ❌ | — | — |  |
-| `--delete-missing-args` | ❌ | — | — |  |
-| `--devices` | ✅ | ❌ | [tests/local_sync_tree.rs](../tests/local_sync_tree.rs) |  |
-| `--dirs` | ❌ | — | — |  |
-| `--dry-run` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  |
-| `--early-input` | ❌ | — | — |  |
-| `--exclude` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  |
-| `--exclude-from` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  |
-| `--executability` | ❌ | — | — |  |
-| `--existing` | ❌ | — | — |  |
-| `--fake-super` | ❌ | — | — |  |
-| `--files-from` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  |
-| `--filter` | ✅ | ✅ | [tests/golden/cli_parity/selection.sh](../tests/golden/cli_parity/selection.sh) |  |
-| `--force` | ❌ | — | — |  |
-| `--from0` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  |
-| `--fsync` | ❌ | — | — |  |
-| `--fuzzy` | ❌ | — | — |  |
-| `--group` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  |
-| `--groupmap` | ❌ | — | — |  |
-| `--hard-links` | ✅ | ❌ | [tests/local_sync_tree.rs](../tests/local_sync_tree.rs) |  |
-| `--help` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  |
-| `--human-readable` | ❌ | — | — |  |
-| `--iconv` | ❌ | — | — |  |
-| `--ignore-errors` | ❌ | — | — |  |
-| `--ignore-existing` | ❌ | — | — |  |
-| `--ignore-missing-args` | ❌ | — | — |  |
-| `--ignore-times` | ❌ | — | — |  |
-| `--include` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  |
-| `--include-from` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  |
-| `--info` | ❌ | — | — |  |
-| `--inplace` | ❌ | — | — |  |
-| `--ipv4` | ❌ | — | — |  |
-| `--ipv6` | ❌ | — | — |  |
-| `--itemize-changes` | ❌ | — | — |  |
-| `--keep-dirlinks` | ❌ | — | — |  |
-| `--link-dest` | ❌ | — | — |  |
-| `--links` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  |
-| `--list-only` | ❌ | — | — |  |
-| `--log-file` | ❌ | — | — |  |
-| `--log-file-format` | ❌ | — | — |  |
-| `--max-alloc` | ❌ | — | — |  |
-| `--max-delete` | ❌ | — | — |  |
-| `--max-size` | ❌ | — | — |  |
-| `--min-size` | ❌ | — | — |  |
-| `--mkpath` | ❌ | — | — |  |
-| `--modify-window` | ❌ | — | — |  |
-| `--munge-links` | ❌ | — | — |  |
-| `--no-OPTION` | ❌ | — | — |  |
-| `--no-implied-dirs` | ❌ | — | — |  |
-| `--no-motd` | ❌ | — | — |  |
-| `--numeric-ids` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  |
-| `--old-args` | ❌ | — | — |  |
-| `--old-dirs` | ❌ | — | — |  |
-| `--omit-dir-times` | ❌ | — | — |  |
-| `--omit-link-times` | ❌ | — | — |  |
-| `--one-file-system` | ❌ | — | — |  |
-| `--only-write-batch` | ❌ | — | — |  |
-| `--open-noatime` | ❌ | — | — |  |
-| `--out-format` | ❌ | — | — |  |
-| `--outbuf` | ❌ | — | — |  |
-| `--owner` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  |
-| `--partial` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  |
-| `--partial-dir` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  |
-| `--password-file` | ✅ | ❌ | [tests/daemon.rs](../tests/daemon.rs) |  |
-| `--perms` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  |
-| `--port` | ❌ | — | — |  |
-| `--preallocate` | ❌ | — | — |  |
-| `--progress` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  |
-| `--protocol` | ❌ | — | — |  |
-| `--prune-empty-dirs` | ❌ | — | — |  |
-| `--quiet` | ✅ | ✅ | [tests/golden/cli_parity/compression.sh](../tests/golden/cli_parity/compression.sh)<br>[tests/golden/cli_parity/delete.sh](../tests/golden/cli_parity/delete.sh)<br>[tests/golden/cli_parity/selection.sh](../tests/golden/cli_parity/selection.sh) |  |
-| `--read-batch` | ❌ | — | — |  |
-| `--recursive` | ✅ | ✅ | [tests/golden/cli_parity/delete.sh](../tests/golden/cli_parity/delete.sh)<br>[tests/golden/cli_parity/compression.sh](../tests/golden/cli_parity/compression.sh)<br>[tests/golden/cli_parity/selection.sh](../tests/golden/cli_parity/selection.sh) |  |
-| `--relative` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  |
-| `--remote-option` | ❌ | — | — |  |
-| `--remove-source-files` | ❌ | — | — |  |
-| `--rsh` | ❌ | — | — |  |
-| `--rsync-path` | ❌ | — | — |  |
-| `--safe-links` | ❌ | — | — |  |
-| `--secluded-args` | ❌ | — | — |  |
-| `--secrets-file` | ✅ | ❌ | [tests/daemon.rs](../tests/daemon.rs) |  |
-| `--size-only` | ❌ | — | — |  |
-| `--skip-compress` | ❌ | — | — |  |
-| `--sockopts` | ❌ | — | — |  |
-| `--sparse` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  |
-| `--specials` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  |
-| `--stats` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  |
-| `--stderr` | ❌ | — | — |  |
-| `--stop-after` | ❌ | — | — |  |
-| `--stop-at` | ❌ | — | — |  |
-| `--suffix` | ❌ | — | — |  |
-| `--super` | ❌ | — | — |  |
-| `--temp-dir` | ❌ | — | — |  |
-| `--timeout` | ❌ | — | — |  |
-| `--times` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  |
-| `--trust-sender` | ❌ | — | — |  |
-| `--update` | ❌ | — | — |  |
-| `--usermap` | ❌ | — | — |  |
-| `--verbose` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  |
-| `--version` | ❌ | — | — |  |
-| `--whole-file` | ❌ | — | — |  |
-| `--write-batch` | ❌ | — | — |  |
-| `--write-devices` | ❌ | — | — |  |
-| `--xattrs` | ❌ | — | — |  |
+| Option | Supported | Parity | Tests | Notes | Enhanced? |
+| --- | --- | --- | --- | --- | --- |
+| `--8-bit-output` | ❌ | — | — |  | |
+| `--acls` | ❌ | — | — |  | |
+| `--address` | ❌ | — | — |  | |
+| `--append` | ❌ | — | — |  | |
+| `--append-verify` | ❌ | — | — |  | |
+| `--archive` | ✅ | ❌ | [tests/interop/run_matrix.sh](../tests/interop/run_matrix.sh) |  | |
+| `--atimes` | ❌ | — | — |  | |
+| `--backup` | ❌ | — | — |  | |
+| `--backup-dir` | ❌ | — | — |  | |
+| `--block-size` | ❌ | — | — |  | |
+| `--blocking-io` | ❌ | — | — |  | |
+| `--bwlimit` | ❌ | — | — |  | |
+| `--checksum` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  | |
+| `--checksum-choice` | ❌ | — | — |  | |
+| `--checksum-seed` | ❌ | — | — |  | |
+| `--chmod` | ❌ | — | — |  | |
+| `--chown` | ❌ | — | — |  | |
+| `--compare-dest` | ❌ | — | — |  | |
+| `--compress` | ✅ | ✅ | [tests/golden/cli_parity/compression.sh](../tests/golden/cli_parity/compression.sh) |  | |
+| `--compress-choice` | ❌ | — | — |  | |
+| `--compress-level` | ✅ | ❌ | [tests/golden/cli_parity/compress-level.sh](../tests/golden/cli_parity/compress-level.sh) |  | |
+| `--contimeout` | ❌ | — | — |  | |
+| `--copy-as` | ❌ | — | — |  | |
+| `--copy-dest` | ❌ | — | — |  | |
+| `--copy-devices` | ❌ | — | — |  | |
+| `--copy-dirlinks` | ❌ | — | — |  | |
+| `--copy-links` | ❌ | — | — |  | |
+| `--copy-unsafe-links` | ❌ | — | — |  | |
+| `--crtimes` | ❌ | — | — |  | |
+| `--cvs-exclude` | ❌ | — | — |  | |
+| `--daemon` | ✅ | ❌ | [tests/daemon.rs](../tests/daemon.rs) |  | |
+| `--debug` | ❌ | — | — |  | |
+| `--delay-updates` | ❌ | — | — |  | |
+| `--delete` | ✅ | ✅ | [tests/golden/cli_parity/delete.sh](../tests/golden/cli_parity/delete.sh) |  | |
+| `--delete-after` | ✅ | ✅ | [tests/golden/cli_parity/delete.sh](../tests/golden/cli_parity/delete.sh) |  | |
+| `--delete-before` | ✅ | ✅ | [tests/golden/cli_parity/delete.sh](../tests/golden/cli_parity/delete.sh) |  | |
+| `--delete-delay` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  | |
+| `--delete-during` | ✅ | ✅ | [tests/golden/cli_parity/delete.sh](../tests/golden/cli_parity/delete.sh) |  | |
+| `--delete-excluded` | ❌ | — | — |  | |
+| `--delete-missing-args` | ❌ | — | — |  | |
+| `--devices` | ✅ | ❌ | [tests/local_sync_tree.rs](../tests/local_sync_tree.rs) |  | |
+| `--dirs` | ❌ | — | — |  | |
+| `--dry-run` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  | |
+| `--early-input` | ❌ | — | — |  | |
+| `--exclude` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  | |
+| `--exclude-from` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  | |
+| `--executability` | ❌ | — | — |  | |
+| `--existing` | ❌ | — | — |  | |
+| `--fake-super` | ❌ | — | — |  | |
+| `--files-from` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  | |
+| `--filter` | ✅ | ✅ | [tests/golden/cli_parity/selection.sh](../tests/golden/cli_parity/selection.sh) |  | |
+| `--force` | ❌ | — | — |  | |
+| `--from0` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  | |
+| `--fsync` | ❌ | — | — |  | |
+| `--fuzzy` | ❌ | — | — |  | |
+| `--group` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  | |
+| `--groupmap` | ❌ | — | — |  | |
+| `--hard-links` | ✅ | ❌ | [tests/local_sync_tree.rs](../tests/local_sync_tree.rs) |  | |
+| `--help` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  | |
+| `--human-readable` | ❌ | — | — |  | |
+| `--iconv` | ❌ | — | — |  | |
+| `--ignore-errors` | ❌ | — | — |  | |
+| `--ignore-existing` | ❌ | — | — |  | |
+| `--ignore-missing-args` | ❌ | — | — |  | |
+| `--ignore-times` | ❌ | — | — |  | |
+| `--include` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  | |
+| `--include-from` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  | |
+| `--info` | ❌ | — | — |  | |
+| `--inplace` | ❌ | — | — |  | |
+| `--ipv4` | ❌ | — | — |  | |
+| `--ipv6` | ❌ | — | — |  | |
+| `--itemize-changes` | ❌ | — | — |  | |
+| `--keep-dirlinks` | ❌ | — | — |  | |
+| `--link-dest` | ❌ | — | — |  | |
+| `--links` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  | |
+| `--list-only` | ❌ | — | — |  | |
+| `--log-file` | ❌ | — | — |  | |
+| `--log-file-format` | ❌ | — | — |  | |
+| `--max-alloc` | ❌ | — | — |  | |
+| `--max-delete` | ❌ | — | — |  | |
+| `--max-size` | ❌ | — | — |  | |
+| `--min-size` | ❌ | — | — |  | |
+| `--mkpath` | ❌ | — | — |  | |
+| `--modify-window` | ❌ | — | — |  | |
+| `--munge-links` | ❌ | — | — |  | |
+| `--no-OPTION` | ❌ | — | — |  | |
+| `--no-implied-dirs` | ❌ | — | — |  | |
+| `--no-motd` | ❌ | — | — |  | |
+| `--numeric-ids` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  | |
+| `--old-args` | ❌ | — | — |  | |
+| `--old-dirs` | ❌ | — | — |  | |
+| `--omit-dir-times` | ❌ | — | — |  | |
+| `--omit-link-times` | ❌ | — | — |  | |
+| `--one-file-system` | ❌ | — | — |  | |
+| `--only-write-batch` | ❌ | — | — |  | |
+| `--open-noatime` | ❌ | — | — |  | |
+| `--out-format` | ❌ | — | — |  | |
+| `--outbuf` | ❌ | — | — |  | |
+| `--owner` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  | |
+| `--partial` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  | |
+| `--partial-dir` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  | |
+| `--password-file` | ✅ | ❌ | [tests/daemon.rs](../tests/daemon.rs) |  | |
+| `--perms` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  | |
+| `--port` | ❌ | — | — |  | |
+| `--preallocate` | ❌ | — | — |  | |
+| `--progress` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  | |
+| `--protocol` | ❌ | — | — |  | |
+| `--prune-empty-dirs` | ❌ | — | — |  | |
+| `--quiet` | ✅ | ✅ | [tests/golden/cli_parity/compression.sh](../tests/golden/cli_parity/compression.sh)<br>[tests/golden/cli_parity/delete.sh](../tests/golden/cli_parity/delete.sh)<br>[tests/golden/cli_parity/selection.sh](../tests/golden/cli_parity/selection.sh) |  | |
+| `--read-batch` | ❌ | — | — |  | |
+| `--recursive` | ✅ | ✅ | [tests/golden/cli_parity/delete.sh](../tests/golden/cli_parity/delete.sh)<br>[tests/golden/cli_parity/compression.sh](../tests/golden/cli_parity/compression.sh)<br>[tests/golden/cli_parity/selection.sh](../tests/golden/cli_parity/selection.sh) |  | |
+| `--relative` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  | |
+| `--remote-option` | ❌ | — | — |  | |
+| `--remove-source-files` | ❌ | — | — |  | |
+| `--rsh` | ❌ | — | [tests/rsh.rs](../tests/rsh.rs) |  | |
+| `--rsync-path` | ❌ | — | [tests/rsync_path.rs](../tests/rsync_path.rs) |  | |
+| `--safe-links` | ❌ | — | — |  | |
+| `--secluded-args` | ❌ | — | — |  | |
+| `--secrets-file` | ✅ | ❌ | [tests/daemon.rs](../tests/daemon.rs) |  | |
+| `--server` | ❌ | — | [tests/server.rs](../tests/server.rs) |  | |
+| `--size-only` | ❌ | — | — |  | |
+| `--skip-compress` | ❌ | — | — |  | |
+| `--sockopts` | ❌ | — | — |  | |
+| `--sparse` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  | |
+| `--specials` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  | |
+| `--stats` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  | |
+| `--stderr` | ❌ | — | — |  | |
+| `--stop-after` | ❌ | — | — |  | |
+| `--stop-at` | ❌ | — | — |  | |
+| `--suffix` | ❌ | — | — |  | |
+| `--super` | ❌ | — | — |  | |
+| `--temp-dir` | ❌ | — | — |  | |
+| `--timeout` | ❌ | — | — |  | |
+| `--times` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  | |
+| `--trust-sender` | ❌ | — | — |  | |
+| `--update` | ❌ | — | — |  | |
+| `--usermap` | ❌ | — | — |  | |
+| `--verbose` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  | |
+| `--version` | ❌ | — | — |  | |
+| `--whole-file` | ❌ | — | — |  | |
+| `--write-batch` | ❌ | — | — |  | |
+| `--write-devices` | ❌ | — | — |  | |
+| `--xattrs` | ❌ | — | — |  | |

--- a/tests/rsh.rs
+++ b/tests/rsh.rs
@@ -1,0 +1,3 @@
+#[test]
+#[ignore = "placeholder for --rsh option"]
+fn rsh_option_placeholder() {}

--- a/tests/rsync_path.rs
+++ b/tests/rsync_path.rs
@@ -1,0 +1,3 @@
+#[test]
+#[ignore = "placeholder for --rsync-path option"]
+fn rsync_path_option_placeholder() {}

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -1,0 +1,3 @@
+#[test]
+#[ignore = "placeholder for --server option"]
+fn server_option_placeholder() {}


### PR DESCRIPTION
## Summary
- add Enhanced? column to feature matrix
- document daemon, server, rsh, and rsync-path options with test links
- add placeholder tests for rsh, rsync-path, and server flags

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68b0cc2bd468832380dee7c9e387be66