### PR TITLE
chore: remove unused import

### DIFF
--- a/crates/protocol/src/server.rs
+++ b/crates/protocol/src/server.rs
@@ -1,7 +1,7 @@
 use std::io::{self, Read, Write};
 use std::time::Duration;
 
-use crate::{negotiate_version, Demux, Frame, Message, Mux};
+use crate::{negotiate_version, Demux, Frame, Mux};
 
 /// Server-side protocol state machine.
 ///


### PR DESCRIPTION
## Summary
- remove unused Message import in protocol server to avoid warnings

## Testing
- `cargo check -p protocol`
- `cargo test -p protocol` *(fails: tests::frame_roundtrip panicked)*

------
https://chatgpt.com/codex/tasks/task_e_68b0d11b8d748323b94f8374dfcd1bd6