### PR TITLE
Gate device node test to Linux

### DIFF
--- a/tests/local_sync_tree.rs
+++ b/tests/local_sync_tree.rs
@@ -2,7 +2,9 @@ use assert_cmd::Command;
 use std::collections::BTreeMap;
 use std::fs;
 #[cfg(unix)]
-use std::os::unix::fs::{FileTypeExt, MetadataExt};
+use std::os::unix::fs::MetadataExt;
+#[cfg(target_os = "linux")]
+use std::os::unix::fs::FileTypeExt;
 use std::path::{Path, PathBuf};
 use tempfile::tempdir;
 
@@ -104,7 +106,7 @@ fn sync_preserves_acls() {
     assert_eq!(acl_src.entries(), acl_dst.entries());
 }
 
-#[cfg(unix)]
+#[cfg(target_os = "linux")]
 #[test]
 fn sync_preserves_device_nodes() {
     use nix::sys::stat::{makedev, mknod, Mode, SFlag};


### PR DESCRIPTION
## Summary
- gate device node sync test to Linux only

## Testing
- `cargo test`
- `cargo test --target x86_64-apple-darwin --no-run` *(fails: ToolExecError: command did not execute successfully)*

------
https://chatgpt.com/codex/tasks/task_e_68b0d422dde883239271bcd725e0174b