### PR TITLE
Detect zero runs to create sparse files

### DIFF
--- a/docs/feature_matrix.md
+++ b/docs/feature_matrix.md
@@ -127,7 +127,7 @@ This table tracks the implementation status of rsync 3.2.x command-line options.
 | `--size-only` | ❌ | — | — |  | |
 | `--skip-compress` | ❌ | — | — |  | |
 | `--sockopts` | ❌ | — | — |  | |
-| `--sparse` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  | |
+| `--sparse` | ✅ | ✅ | [tests/cli.rs](../tests/cli.rs) | creates holes for long zero runs | |
 | `--specials` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  | |
 | `--stats` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  | |
 | `--stderr` | ❌ | — | — |  | |


### PR DESCRIPTION
## Summary
- use seek when writing long zero runs to create sparse holes
- set output length after applying deltas for trailing holes
- test sparse file creation and update feature matrix parity

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68b0d92787a08323ba6aadc4d95793cd