### PR TITLE
docs: document checksum and deletion parity

### DIFF
--- a/docs/differences.md
+++ b/docs/differences.md
@@ -3,13 +3,14 @@
 `rsync-rs` strives to mirror the traditional `rsync` command line. The table
 below highlights how common flags map to current support and how the
 `--modern` convenience flag influences behavior. For a complete listing see
-[cli/flags.md](cli/flags.md).
+[cli/flags.md](cli/flags.md). For detailed parity status see
+[feature_matrix.md](feature_matrix.md).
 
 | rsync flag | rsync-rs status | `--modern` notes |
 |------------|-----------------|------------------|
 | `-z`, `--compress` | ✅ uses zlib by default | negotiates zstd if both peers support it |
 | `--compress-level` | ✅ maps numeric levels | applies to zlib or zstd |
-| `-c`, `--checksum` | ❌ parsed but not implemented | would switch to BLAKE3 when available |
+| `-c`, `--checksum` | ✅ strong hashes: MD5 (default), SHA-1, BLAKE3 | `--modern` selects BLAKE3 |
 | `-a`, `--archive` | ✅ sets perms, times, owner, group, links, devices, specials | n/a |
 | `-R`, `--relative` | ✅ preserves ancestor directories | n/a |
 | `-P` | ✅ keeps partial files and shows progress | n/a |
@@ -20,8 +21,9 @@ below highlights how common flags map to current support and how the
 
 - `--daemon` and `--server` have the same syntax and defaults as `rsync`; see [cli.md](cli.md#daemon-and-server-modes).
 - `-e`/`--rsh` defaults to `ssh` and honors the `RSYNC_RSH` environment variable; see [cli.md](cli.md#remote-shell).
-- Only `--delete` is currently supported among deletion flags. Other variants are
-  parsed but not implemented. See [cli.md](cli.md#deletion-flags).
+- Deletion flags `--delete-before`, `--delete-during`, and `--delete-after` are
+  implemented. See [cli.md](cli.md#deletion-flags) and
+  [feature_matrix.md](feature_matrix.md) for parity details.
 - Advanced transfer options such as `--partial`, `--bwlimit`, and `--link-dest`
   behave like `rsync` when available; see
   [cli.md](cli.md#advanced-transfer-options).

--- a/docs/feature_matrix.md
+++ b/docs/feature_matrix.md
@@ -1,6 +1,7 @@
 # Feature Matrix
 
 This table tracks the implementation status of rsync 3.2.x command-line options.
+See [differences.md](differences.md) for a summary of notable behavioral differences.
 
 | Option | Supported | Parity | Tests | Notes | Enhanced? |
 | --- | --- | --- | --- | --- | --- |
@@ -16,7 +17,7 @@ This table tracks the implementation status of rsync 3.2.x command-line options.
 | `--block-size` | ❌ | — | — |  | |
 | `--blocking-io` | ❌ | — | — |  | |
 | `--bwlimit` | ❌ | — | — |  | |
-| `--checksum` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  | |
+| `--checksum` | ✅ | ✅ | [tests/cli.rs](../tests/cli.rs) | strong hashes: MD5 (default), SHA-1, BLAKE3 | |
 | `--checksum-choice` | ❌ | — | — |  | |
 | `--checksum-seed` | ❌ | — | — |  | |
 | `--chmod` | ❌ | — | — |  | |


### PR DESCRIPTION
## Summary
- document that `--checksum` is implemented with MD5, SHA-1 and BLAKE3 support
- note support for `--delete-before`, `--delete-during`, and `--delete-after`
- cross-link `differences.md` and `feature_matrix.md` to keep parity info aligned

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68b0d9b0b7f083239a1ceff84e61b11a