### PR TITLE
Document missing rsync behaviors and flag aliases

### DIFF
--- a/docs/feature_matrix.md
+++ b/docs/feature_matrix.md
@@ -17,6 +17,7 @@ See [differences.md](differences.md) for a summary of notable behavioral differe
 | `--block-size` | ❌ | — | — |  | |
 | `--blocking-io` | ❌ | — | — |  | |
 | `--bwlimit` | ❌ | — | — |  | |
+| `--cc` | ❌ | — | [gaps.md](gaps.md) | alias for `--checksum-choice` | |
 | `--checksum` | ✅ | ✅ | [tests/cli.rs](../tests/cli.rs) | strong hashes: MD5 (default), SHA-1, BLAKE3 | |
 | `--checksum-choice` | ❌ | — | — |  | |
 | `--checksum-seed` | ❌ | — | — |  | |
@@ -26,6 +27,8 @@ See [differences.md](differences.md) for a summary of notable behavioral differe
 | `--compress` | ✅ | ✅ | [tests/golden/cli_parity/compression.sh](../tests/golden/cli_parity/compression.sh) |  | |
 | `--compress-choice` | ❌ | — | — |  | |
 | `--compress-level` | ✅ | ❌ | [tests/golden/cli_parity/compress-level.sh](../tests/golden/cli_parity/compress-level.sh) |  | |
+| `--zc` | ❌ | — | [gaps.md](gaps.md) | alias for `--compress-choice` | |
+| `--zl` | ❌ | — | [gaps.md](gaps.md) | alias for `--compress-level` | |
 | `--contimeout` | ❌ | — | — |  | |
 | `--copy-as` | ❌ | — | — |  | |
 | `--copy-dest` | ❌ | — | — |  | |
@@ -37,6 +40,7 @@ See [differences.md](differences.md) for a summary of notable behavioral differe
 | `--cvs-exclude` | ❌ | — | — |  | |
 | `--daemon` | ✅ | ❌ | [tests/daemon.rs](../tests/daemon.rs) |  | |
 | `--debug` | ❌ | — | — |  | |
+| `--del` | ✅ | ✅ | [tests/golden/cli_parity/delete.sh](../tests/golden/cli_parity/delete.sh) | alias for `--delete-during` | |
 | `--delay-updates` | ❌ | — | — |  | |
 | `--delete` | ✅ | ✅ | [tests/golden/cli_parity/delete.sh](../tests/golden/cli_parity/delete.sh) |  | |
 | `--delete-after` | ✅ | ✅ | [tests/golden/cli_parity/delete.sh](../tests/golden/cli_parity/delete.sh) |  | |
@@ -90,11 +94,13 @@ See [differences.md](differences.md) for a summary of notable behavioral differe
 | `--mkpath` | ❌ | — | — |  | |
 | `--modify-window` | ❌ | — | — |  | |
 | `--munge-links` | ❌ | — | — |  | |
+| `--no-D` | ❌ | — | [gaps.md](gaps.md) | alias for `--no-devices --no-specials` | |
 | `--no-OPTION` | ❌ | — | — |  | |
 | `--no-implied-dirs` | ❌ | — | — |  | |
 | `--no-motd` | ❌ | — | — |  | |
 | `--numeric-ids` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  | |
 | `--old-args` | ❌ | — | — |  | |
+| `--old-d` | ❌ | — | [gaps.md](gaps.md) | alias for `--old-dirs` | |
 | `--old-dirs` | ❌ | — | — |  | |
 | `--omit-dir-times` | ❌ | — | — |  | |
 | `--omit-link-times` | ❌ | — | — |  | |

--- a/docs/gaps.md
+++ b/docs/gaps.md
@@ -3,11 +3,27 @@
 This document tracks outstanding gaps in `rsync-rs` compared to the reference `rsync` implementation. Update this file as features are implemented.
 
 ## Missing rsync behaviors
+
+### Protocol gaps
 - The `--server` handshake is not implemented, leaving server-mode negotiation incomplete; see the `--protocol` entry in `docs/feature_matrix.md`.
-- Remote shell (`--rsh`) handling is incomplete (see the `--rsh` row in `docs/feature_matrix.md`).
-- Daemon mode achieves only partial feature parity; `--password-file` and `--secrets-file` remain incomplete (see `docs/feature_matrix.md`).
-- Filter rules are incomplete and do not yet match `rsync`'s full include/exclude syntax.
+- Remote shell (`--rsh`) negotiation is incomplete, lacking full `rsh` command parsing and environment handshakes.
+- Partial transfer resumption does not fully match `rsync` semantics; interrupted copies cannot reuse partially transferred data.
 - Compression negotiation between peers is unimplemented.
+
+### Metadata gaps
+- ACL (`--acls`) and extended attribute (`--xattrs`) preservation are unsupported.
+- File time preservation is incomplete; access times (`--atimes`) and creation times (`--crtimes`) are not handled.
+- Enhanced metadata such as permissions, owners, and groups lack full parity with GNU rsync.
+
+### Filter gaps
+- Filter rules are incomplete and do not yet match `rsync`'s full include/exclude syntax.
+- Per-directory `.rsync-filter` handling and `-F` convenience flag semantics are unimplemented.
+
+### Daemon gaps
+- Daemon mode achieves only partial feature parity; `--password-file` and `--secrets-file` remain incomplete (see `docs/feature_matrix.md`).
+- Daemon sessions do not support ACL/xattr preservation.
+- Module options such as `--log-file`, `--log-file-format`, and MOTD control have not been implemented.
+
 - Many command-line options remain absent or lack parity; see `docs/feature_matrix.md` for the full matrix.
 
 ## Unreachable code


### PR DESCRIPTION
## Summary
- document protocol, metadata, filter, and daemon gaps against rsync 3.2.x
- expand feature matrix with alias flags and tracing links

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68b0dc220e788323bcb796b81bb664f4