### PR TITLE
Clarify sparse file handling and requirements

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -38,7 +38,8 @@ struct ClientOpts {
     /// perform a trial run with no changes made
     #[arg(short = 'n', long, help_heading = "Selection")]
     dry_run: bool,
-    /// turn sequences of nulls into sparse blocks
+    /// turn sequences of nulls into sparse blocks and preserve existing holes
+    /// (requires filesystem support)
     #[arg(short = 'S', long, help_heading = "Selection")]
     sparse: bool,
     /// increase logging verbosity

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -84,6 +84,10 @@ These flags mirror `rsync(1)` features that fine‑tune how data is copied.
 - `--partial-dir <DIR>` – place partial files in `DIR`.
 - `--append` / `--append-verify` – append data to existing files rather than
   replacing them.
+- `--sparse` – convert long sequences of zero bytes into holes and preserve
+  holes in sparse source files. The destination filesystem must support sparse
+  files. See `tests/cli.rs::sparse_files_created` and
+  `tests/cli.rs::sparse_files_preserved` for examples.
 - `--bwlimit <RATE>` – throttle I/O bandwidth to `RATE` bytes per second.
 - `--link-dest <DIR>` / `--copy-dest <DIR>` – hard‑link or copy unchanged
   files from `DIR`.


### PR DESCRIPTION
## Summary
- document that `--sparse` preserves holes and requires filesystem support
- expand `--sparse` CLI help accordingly

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b0e97b7ce883238460c5b6e36d56c1