### PR TITLE
Preserve sparse file holes at EOF

### DIFF
--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -285,6 +285,11 @@ where
             let op = op?;
             apply_op_sparse(basis, op, file, &mut buf)?;
         }
+        // Ensure the final file length accounts for any trailing holes by
+        // explicitly setting it to the current position. This avoids writing
+        // zeros while still extending the file sparsely.
+        let pos = file.stream_position()?;
+        file.set_len(pos)?;
     } else {
         for op in ops {
             let op = op?;

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -603,8 +603,13 @@ fn sparse_files_preserved() {
     std::fs::create_dir_all(&dst).unwrap();
     let sp = src.join("sparse");
     let mut f = File::create(&sp).unwrap();
+    // Write non-zero data after an initial hole and then extend the file again
+    // to leave a trailing hole. This ensures that sparse regions at the end of
+    // the file are preserved by the sync engine.
     f.seek(SeekFrom::Start(1 << 20)).unwrap();
     f.write_all(b"end").unwrap();
+    // Create a trailing hole beyond the written data.
+    f.set_len(1 << 21).unwrap();
 
     let src_arg = format!("{}/", src.display());
     Command::cargo_bin("rsync-rs")


### PR DESCRIPTION
## Summary
- ensure trailing sparse regions extend files without zero writes
- cover sparse file with trailing hole in CLI tests

## Testing
- `cargo test -q`
- `cargo test -q --test cli sparse_files_preserved`


------
https://chatgpt.com/codex/tasks/task_e_68b0e961c5908323a99e1aded36c13f0