### PR TITLE
Handle missing destination file names

### DIFF
--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -373,9 +373,11 @@ impl Sender {
 
         let src = File::open(path)?;
         let mut src_reader = BufReader::new(src);
+        let file_name = dest
+            .file_name()
+            .ok_or_else(|| EngineError::Other("destination has no file name".into()))?;
         let partial_path = if let Some(dir) = &self.opts.partial_dir {
-            dir.join(dest.file_name().unwrap())
-                .with_extension("partial")
+            dir.join(file_name).with_extension("partial")
         } else {
             dest.with_extension("partial")
         };
@@ -455,9 +457,11 @@ impl Receiver {
         I: IntoIterator<Item = Result<Op>>,
     {
         self.state = ReceiverState::Applying;
+        let file_name = dest
+            .file_name()
+            .ok_or_else(|| EngineError::Other("destination has no file name".into()))?;
         let partial = if let Some(dir) = &self.opts.partial_dir {
-            dir.join(dest.file_name().unwrap())
-                .with_extension("partial")
+            dir.join(file_name).with_extension("partial")
         } else {
             dest.with_extension("partial")
         };


### PR DESCRIPTION
## Summary
- avoid panics when building partial paths by returning an `EngineError` if the destination has no file name
- propagate destination file name errors in receiver

## Testing
- `cargo fmt -- crates/engine/src/lib.rs`
- `cargo test` *(fails: remote_to_remote tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b14145cb6c8323bd8519afb8171b94