### PR TITLE
feat: add server handshake negotiation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -994,6 +994,7 @@ name = "protocol"
 version = "0.1.0"
 dependencies = [
  "byteorder",
+ "compress",
  "indexmap",
 ]
 

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -816,7 +816,8 @@ fn run_server() -> Result<()> {
     let stdin = io::stdin();
     let stdout = io::stdout();
     let mut srv = Server::new(stdin.lock(), stdout.lock());
-    srv.handshake()
+    let _ = srv
+        .handshake()
         .map_err(|e| EngineError::Other(e.to_string()))?;
     Ok(())
 }

--- a/crates/protocol/Cargo.toml
+++ b/crates/protocol/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2021"
 [dependencies]
 byteorder = "1"
 indexmap = "2"
+compress = { path = "../compress" }

--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -141,6 +141,7 @@ impl TryFrom<u8> for Msg {
             5 => Ok(Msg::Attributes),
             6 => Ok(Msg::Error),
             7 => Ok(Msg::Progress),
+            8 => Ok(Msg::Codecs),
             other => Err(UnknownMsg(other)),
         }
     }

--- a/crates/protocol/tests/server.rs
+++ b/crates/protocol/tests/server.rs
@@ -1,12 +1,26 @@
+use compress::{available_codecs, encode_codecs};
 use protocol::{Server, LATEST_VERSION};
-use std::io::{Cursor, Read, Write};
+use std::io::Cursor;
 
 #[test]
 fn server_negotiates_version() {
-    let mut input = Cursor::new(LATEST_VERSION.to_be_bytes().to_vec());
+    let payload = encode_codecs(available_codecs());
+    let mut input = Cursor::new({
+        let mut v = LATEST_VERSION.to_be_bytes().to_vec();
+        v.push(payload.len() as u8);
+        v.extend_from_slice(&payload);
+        v
+    });
     let mut output = Vec::new();
     let mut srv = Server::new(&mut input, &mut output);
-    let ver = srv.handshake().unwrap();
-    assert_eq!(ver, LATEST_VERSION);
-    assert_eq!(output, LATEST_VERSION.to_be_bytes());
+    let peer_codecs = srv.handshake().unwrap();
+    assert_eq!(srv.version, LATEST_VERSION);
+    assert_eq!(peer_codecs, available_codecs());
+    let expected = {
+        let mut v = LATEST_VERSION.to_be_bytes().to_vec();
+        v.push(payload.len() as u8);
+        v.extend_from_slice(&payload);
+        v
+    };
+    assert_eq!(output, expected);
 }

--- a/docs/feature_matrix.md
+++ b/docs/feature_matrix.md
@@ -130,7 +130,7 @@ See [differences.md](differences.md) for a summary of notable behavioral differe
 | `--safe-links` | ❌ | — | — |  | |
 | `--secluded-args` | ❌ | — | — |  | |
 | `--secrets-file` | ✅ | ❌ | [tests/daemon.rs](../tests/daemon.rs) |  | |
-| `--server` | ❌ | — | [tests/server.rs](../tests/server.rs) |  | |
+| `--server` | ✅ | ❌ | [tests/server.rs](../tests/server.rs) | negotiates protocol version and codecs | |
 | `--size-only` | ❌ | — | — |  | |
 | `--skip-compress` | ❌ | — | — |  | |
 | `--sockopts` | ❌ | — | — |  | |

--- a/docs/gaps.md
+++ b/docs/gaps.md
@@ -5,7 +5,6 @@ This document tracks outstanding gaps in `rsync-rs` compared to the reference `r
 ## Missing rsync behaviors
 
 ### Protocol gaps
-- The `--server` handshake is not implemented, leaving server-mode negotiation incomplete; see the `--protocol` entry in `docs/feature_matrix.md`.
 - Remote shell (`--rsh`) negotiation is incomplete, lacking full `rsh` command parsing and environment handshakes.
 - Partial transfer resumption does not fully match `rsync` semantics; interrupted copies cannot reuse partially transferred data.
 - Compression negotiation between peers is unimplemented.

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -1,9 +1,15 @@
+use assert_cmd::cargo::cargo_bin;
+use compress::{available_codecs, decode_codecs, encode_codecs};
+use protocol::{LATEST_VERSION, MIN_VERSION};
+use std::fs;
+use std::io::{Read, Write};
+use std::process::{Command, Stdio};
 use tempfile::tempdir;
+
 #[cfg(unix)]
 mod remote_utils;
 #[cfg(unix)]
 use remote_utils::{spawn_reader, spawn_writer};
-use std::fs;
 
 #[cfg(unix)]
 #[test]
@@ -18,4 +24,62 @@ fn server_remote_pair_reports_error() {
     let (_, mut dst_writer) = dst_session.into_inner();
     let res = std::io::copy(&mut src_reader, &mut dst_writer);
     assert!(res.is_err());
+}
+
+#[test]
+fn server_handshake_succeeds() {
+    let exe = cargo_bin("rsync-rs");
+    let mut child = Command::new(exe)
+        .arg("--server")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()
+        .unwrap();
+    let mut stdin = child.stdin.take().unwrap();
+    let mut stdout = child.stdout.take().unwrap();
+
+    // Send our version.
+    stdin.write_all(&LATEST_VERSION.to_be_bytes()).unwrap();
+
+    // Receive negotiated version.
+    let mut ver_buf = [0u8; 4];
+    stdout.read_exact(&mut ver_buf).unwrap();
+    assert_eq!(u32::from_be_bytes(ver_buf), LATEST_VERSION);
+
+    // Send codec list.
+    let codecs = available_codecs();
+    let payload = encode_codecs(codecs);
+    stdin.write_all(&[payload.len() as u8]).unwrap();
+    stdin.write_all(&payload).unwrap();
+
+    // Receive server codec list.
+    let mut len = [0u8; 1];
+    stdout.read_exact(&mut len).unwrap();
+    let mut buf = vec![0u8; len[0] as usize];
+    stdout.read_exact(&mut buf).unwrap();
+    let server_codecs = decode_codecs(&buf).unwrap();
+    assert_eq!(server_codecs, codecs);
+
+    let status = child.wait().unwrap();
+    assert!(status.success());
+}
+
+#[test]
+fn server_rejects_unsupported_version() {
+    let exe = cargo_bin("rsync-rs");
+    let mut child = Command::new(exe)
+        .arg("--server")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()
+        .unwrap();
+    let mut stdin = child.stdin.take().unwrap();
+
+    // Send an unsupported version.
+    let bad = (MIN_VERSION - 1) as u32;
+    stdin.write_all(&bad.to_be_bytes()).unwrap();
+    drop(stdin);
+
+    let status = child.wait().unwrap();
+    assert!(!status.success());
 }


### PR DESCRIPTION
## Summary
- handle version and codec negotiation in `--server` mode
- respond to handshake in CLI server flow
- document server handshake and close gap entry

## Testing
- `cargo test server_handshake_succeeds -- --nocapture`
- `cargo test server_rejects_unsupported_version -- --nocapture`
- `cargo test -p protocol`
- `cargo test` *(fails: remote_to_remote_failure_and_reconnect, remote_to_remote_reports_errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b1415bbe648323abef1df7fc1fbf25