### PR TITLE
Add --inplace option for direct file updates

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -123,6 +123,9 @@ struct ClientOpts {
     /// keep partially transferred files and show progress
     #[arg(short = 'P', help_heading = "Misc")]
     partial_progress: bool,
+    /// update destination files in-place
+    #[arg(short = 'I', long, help_heading = "Misc")]
+    inplace: bool,
     /// don't map uid/gid values by user/group name
     #[arg(long, help_heading = "Attributes")]
     numeric_ids: bool,
@@ -507,6 +510,7 @@ fn run_client(opts: ClientOpts) -> Result<()> {
         progress: opts.progress || opts.partial_progress,
         partial_dir: opts.partial_dir.clone(),
         numeric_ids: opts.numeric_ids,
+        inplace: opts.inplace,
     };
     let stats = if opts.local {
         match (src, dst) {

--- a/docs/feature_matrix.md
+++ b/docs/feature_matrix.md
@@ -77,7 +77,7 @@ See [differences.md](differences.md) for a summary of notable behavioral differe
 | `--include` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  | |
 | `--include-from` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  | |
 | `--info` | ❌ | — | — |  | |
-| `--inplace` | ❌ | — | — |  | |
+| `--inplace` | ✅ | ✅ | [tests/golden/cli_parity/inplace.sh](../tests/golden/cli_parity/inplace.sh) |  | |
 | `--ipv4` | ❌ | — | — |  | |
 | `--ipv6` | ❌ | — | — |  | |
 | `--itemize-changes` | ❌ | — | — |  | |

--- a/tests/golden/cli_parity/inplace.sh
+++ b/tests/golden/cli_parity/inplace.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+RSYNC_RS="$ROOT/target/debug/rsync-rs"
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+mkdir -p "$TMP/src" "$TMP/rsync_dst" "$TMP/rsync_rs_dst"
+
+echo olddata > "$TMP/rsync_dst/file.txt"
+cp "$TMP/rsync_dst/file.txt" "$TMP/rsync_rs_dst/file.txt"
+sleep 1
+echo newdata > "$TMP/src/file.txt"
+
+rsync_output=$(rsync --quiet --recursive --inplace "$TMP/src/" "$TMP/rsync_dst" 2>&1)
+rsync_status=$?
+
+rsync_rs_raw=$("$RSYNC_RS" --local --recursive --inplace "$TMP/src/" "$TMP/rsync_rs_dst" 2>&1)
+rsync_rs_status=$?
+rsync_rs_output=$(echo "$rsync_rs_raw" | grep -v 'recursive mode enabled' || true)
+
+if [ "$rsync_status" -ne "$rsync_rs_status" ]; then
+  echo "Exit codes differ: rsync=$rsync_status rsync-rs=$rsync_rs_status" >&2
+  exit 1
+fi
+
+if [ "$rsync_output" != "$rsync_rs_output" ]; then
+  echo "Outputs differ" >&2
+  diff -u <(printf "%s" "$rsync_output") <(printf "%s" "$rsync_rs_output") >&2 || true
+  exit 1
+fi
+
+if ! diff -r "$TMP/rsync_dst" "$TMP/rsync_rs_dst" >/dev/null; then
+  echo "Directory trees differ" >&2
+  diff -r "$TMP/rsync_dst" "$TMP/rsync_rs_dst" >&2 || true
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- add `--inplace` (`-I`) CLI flag to allow in-place updates
- propagate flag to engine via new `SyncOptions::inplace`
- implement in-place delta application and document support
- add rsync compatibility test for `--inplace`

## Testing
- `cargo test` *(fails: remote_to_remote_failure_and_reconnect, remote_to_remote_reports_errors)*
- `make test-golden`


------
https://chatgpt.com/codex/tasks/task_e_68b14b133c1c83238e643fb580183afc