### PR TITLE
Add resumable partial transfers and CLI support

### DIFF
--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -100,6 +100,26 @@ fn resumes_from_partial_dir() {
 }
 
 #[test]
+fn resumes_from_partial_file() {
+    let dir = tempdir().unwrap();
+    let src_dir = dir.path().join("src");
+    let dst_dir = dir.path().join("dst");
+    std::fs::create_dir_all(&src_dir).unwrap();
+    std::fs::create_dir_all(&dst_dir).unwrap();
+    std::fs::write(src_dir.join("a.txt"), b"hello").unwrap();
+    std::fs::write(dst_dir.join("a.partial"), b"he").unwrap();
+
+    let mut cmd = Command::cargo_bin("rsync-rs").unwrap();
+    let src_arg = format!("{}/", src_dir.display());
+    cmd.args(["--local", "--partial", &src_arg, dst_dir.to_str().unwrap()]);
+    cmd.assert().success();
+
+    let out = std::fs::read(dst_dir.join("a.txt")).unwrap();
+    assert_eq!(out, b"hello");
+    assert!(!dst_dir.join("a.partial").exists());
+}
+
+#[test]
 fn numeric_ids_are_preserved() {
     let dir = tempdir().unwrap();
     let src_dir = dir.path().join("src");


### PR DESCRIPTION
## Summary
- resume transfers from existing partial files by skipping completed bytes
- add `--partial` and `--partial-dir` handling to persist temporary files
- test local and remote resume scenarios

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68b151fd1c488323bd9eabbb65ee596f