### PR TITLE
Add daemon access control, motd, and auth options

### DIFF
--- a/docs/daemon.md
+++ b/docs/daemon.md
@@ -37,14 +37,35 @@ Before serving files the daemon confines itself to the module root. On Unix plat
 
 ## Hosts allow/deny lists
 
-Future releases will honor `hosts allow` and `hosts deny` directives similar to `rsyncd.conf`. A typical configuration might look like:
+The daemon can restrict connections based on client address. The `--hosts-allow`
+and `--hosts-deny` flags accept comma separated IP addresses. A client must match
+the allow list (if supplied) and must not match the deny list:
 
-```
-[logs]
-    path = /srv/logs
-    hosts allow = 192.0.2.0/24, 198.51.100.7
-    hosts deny  = *
+```bash
+rsync-rs --daemon \
+    --module logs=/srv/logs \
+    --hosts-allow=127.0.0.1 \
+    --hosts-deny=*
 ```
 
-Clients whose address does not match the allow list will be denied before authentication. This functionality is under active development.
+Clients whose address does not satisfy these rules are disconnected before any
+authentication takes place.
+
+## Logging
+
+Supply `--log-file` to record daemon activity. The optional
+`--log-file-format` flag controls the line format and supports `%h` for the
+client host and `%m` for the requested module:
+
+```bash
+rsync-rs --daemon --module data=/srv/export \
+    --log-file=/var/log/rsyncd.log \
+    --log-file-format="%h %m"
+```
+
+## Message of the day
+
+Use `--motd` to display a message of the day to connecting clients. Each line in
+the file is sent with the `@RSYNCD:` prefix during the handshake. Clients may
+suppress the message with `--no-motd`.
 

--- a/docs/gaps.md
+++ b/docs/gaps.md
@@ -18,9 +18,6 @@ This document tracks outstanding gaps in `rsync-rs` compared to the reference `r
 - Per-directory `.rsync-filter` handling and `-F` convenience flag semantics are unimplemented.
 
 ### Daemon gaps
-- Daemon mode achieves only partial feature parity; `--password-file` and `--secrets-file` remain incomplete (see `docs/feature_matrix.md`).
-- Module options such as `--log-file`, `--log-file-format`, and MOTD control have not been implemented.
-
 - Many command-line options remain absent or lack parity; see `docs/feature_matrix.md` for the full matrix.
 
 ## Unreachable code


### PR DESCRIPTION
## Summary
- implement password file permission checks
- add host allow/deny, logging, and MOTD options for the daemon
- document daemon access control and add tests for allow/deny and MOTD

## Testing
- `cargo test --test daemon`


------
https://chatgpt.com/codex/tasks/task_e_68b15f861a748323b624f801c2729347