### PR TITLE
docs: expand feature matrix metadata

### DIFF
--- a/docs/feature_matrix.md
+++ b/docs/feature_matrix.md
@@ -3,154 +3,154 @@
 This table tracks the implementation status of rsync 3.2.x command-line options.
 See [differences.md](differences.md) for a summary of notable behavioral differences.
 
-| Option | Supported | Parity | Tests | Notes | Enhanced? |
-| --- | --- | --- | --- | --- | --- |
-| `--8-bit-output` | ❌ | — | — |  | |
-| `--acls` | ✅ | ❌ | [tests/local_sync_tree.rs](../tests/local_sync_tree.rs)<br>[tests/daemon_sync_attrs.rs](../tests/daemon_sync_attrs.rs) | requires `acl` feature | |
-| `--address` | ❌ | — | — |  | |
-| `--append` | ❌ | — | — |  | |
-| `--append-verify` | ❌ | — | — |  | |
-| `--archive` | ✅ | ❌ | [tests/interop/run_matrix.sh](../tests/interop/run_matrix.sh) |  | |
-| `--atimes` | ❌ | — | — |  | |
-| `--backup` | ❌ | — | — |  | |
-| `--backup-dir` | ❌ | — | — |  | |
-| `--block-size` | ❌ | — | — |  | |
-| `--blocking-io` | ❌ | — | — |  | |
-| `--bwlimit` | ❌ | — | — |  | |
-| `--cc` | ❌ | — | [gaps.md](gaps.md) | alias for `--checksum-choice` | |
-| `--checksum` | ✅ | ✅ | [tests/cli.rs](../tests/cli.rs) | strong hashes: MD5 (default), SHA-1, BLAKE3 | |
-| `--checksum-choice` | ❌ | — | — |  | |
-| `--checksum-seed` | ❌ | — | — |  | |
-| `--chmod` | ❌ | — | — |  | |
-| `--chown` | ❌ | — | — |  | |
-| `--compare-dest` | ❌ | — | — |  | |
-| `--compress` | ✅ | ✅ | [tests/golden/cli_parity/compression.sh](../tests/golden/cli_parity/compression.sh)<br>[tests/compression_negotiation.sh](../tests/compression_negotiation.sh) | negotiates zstd when supported by both peers | |
-| `--compress-choice` | ❌ | — | — |  | |
-| `--compress-level` | ✅ | ❌ | [tests/golden/cli_parity/compress-level.sh](../tests/golden/cli_parity/compress-level.sh) |  | |
-| `--zc` | ❌ | — | [gaps.md](gaps.md) | alias for `--compress-choice` | |
-| `--zl` | ❌ | — | [gaps.md](gaps.md) | alias for `--compress-level` | |
-| `--contimeout` | ❌ | — | — |  | |
-| `--copy-as` | ❌ | — | — |  | |
-| `--copy-dest` | ❌ | — | — |  | |
-| `--copy-devices` | ❌ | — | — |  | |
-| `--copy-dirlinks` | ❌ | — | — |  | |
-| `--copy-links` | ❌ | — | — |  | |
-| `--copy-unsafe-links` | ❌ | — | — |  | |
-| `--crtimes` | ❌ | — | — |  | |
-| `--cvs-exclude` | ❌ | — | — |  | |
-| `--daemon` | ✅ | ❌ | [tests/daemon.rs](../tests/daemon.rs) |  | |
-| `--debug` | ❌ | — | — |  | |
-| `--del` | ✅ | ✅ | [tests/golden/cli_parity/delete.sh](../tests/golden/cli_parity/delete.sh) | alias for `--delete-during` | |
-| `--delay-updates` | ❌ | — | — |  | |
-| `--delete` | ✅ | ✅ | [tests/golden/cli_parity/delete.sh](../tests/golden/cli_parity/delete.sh) |  | |
-| `--delete-after` | ✅ | ✅ | [tests/golden/cli_parity/delete.sh](../tests/golden/cli_parity/delete.sh) |  | |
-| `--delete-before` | ✅ | ✅ | [tests/golden/cli_parity/delete.sh](../tests/golden/cli_parity/delete.sh) |  | |
-| `--delete-delay` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  | |
-| `--delete-during` | ✅ | ✅ | [tests/golden/cli_parity/delete.sh](../tests/golden/cli_parity/delete.sh) |  | |
-| `--delete-excluded` | ❌ | — | — |  | |
-| `--delete-missing-args` | ❌ | — | — |  | |
-| `--devices` | ✅ | ❌ | [tests/local_sync_tree.rs](../tests/local_sync_tree.rs) |  | |
-| `--dirs` | ❌ | — | — |  | |
-| `--dry-run` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  | |
-| `--early-input` | ❌ | — | — |  | |
-| `--exclude` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  | |
-| `--exclude-from` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  | |
-| `--executability` | ❌ | — | — |  | |
-| `--existing` | ❌ | — | — |  | |
-| `--fake-super` | ❌ | — | — |  | |
-| `--files-from` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  | |
-| `--filter` | ✅ | ✅ | [tests/golden/cli_parity/selection.sh](../tests/golden/cli_parity/selection.sh) |  | |
-| `--force` | ❌ | — | — |  | |
-| `--from0` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  | |
-| `--fsync` | ❌ | — | — |  | |
-| `--fuzzy` | ❌ | — | — |  | |
-| `--group` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  | |
-| `--groupmap` | ❌ | — | — |  | |
-| `--hard-links` | ✅ | ❌ | [tests/local_sync_tree.rs](../tests/local_sync_tree.rs) |  | |
-| `--help` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  | |
-| `--human-readable` | ❌ | — | — |  | |
-| `--iconv` | ❌ | — | — |  | |
-| `--ignore-errors` | ❌ | — | — |  | |
-| `--ignore-existing` | ❌ | — | — |  | |
-| `--ignore-missing-args` | ❌ | — | — |  | |
-| `--ignore-times` | ❌ | — | — |  | |
-| `--include` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  | |
-| `--include-from` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  | |
-| `--info` | ❌ | — | — |  | |
-| `--inplace` | ✅ | ✅ | [tests/golden/cli_parity/inplace.sh](../tests/golden/cli_parity/inplace.sh) |  | |
-| `--ipv4` | ❌ | — | — |  | |
-| `--ipv6` | ❌ | — | — |  | |
-| `--itemize-changes` | ❌ | — | — |  | |
-| `--keep-dirlinks` | ❌ | — | — |  | |
-| `--link-dest` | ❌ | — | — |  | |
-| `--links` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  | |
-| `--list-only` | ❌ | — | — |  | |
-| `--log-file` | ❌ | — | — |  | |
-| `--log-file-format` | ❌ | — | — |  | |
-| `--max-alloc` | ❌ | — | — |  | |
-| `--max-delete` | ❌ | — | — |  | |
-| `--max-size` | ❌ | — | — |  | |
-| `--min-size` | ❌ | — | — |  | |
-| `--mkpath` | ❌ | — | — |  | |
-| `--modify-window` | ❌ | — | — |  | |
-| `--munge-links` | ❌ | — | — |  | |
-| `--no-D` | ❌ | — | [gaps.md](gaps.md) | alias for `--no-devices --no-specials` | |
-| `--no-OPTION` | ❌ | — | — |  | |
-| `--no-implied-dirs` | ❌ | — | — |  | |
-| `--no-motd` | ❌ | — | — |  | |
-| `--numeric-ids` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  | |
-| `--old-args` | ❌ | — | — |  | |
-| `--old-d` | ❌ | — | [gaps.md](gaps.md) | alias for `--old-dirs` | |
-| `--old-dirs` | ❌ | — | — |  | |
-| `--omit-dir-times` | ❌ | — | — |  | |
-| `--omit-link-times` | ❌ | — | — |  | |
-| `--one-file-system` | ❌ | — | — |  | |
-| `--only-write-batch` | ❌ | — | — |  | |
-| `--open-noatime` | ❌ | — | — |  | |
-| `--out-format` | ❌ | — | — |  | |
-| `--outbuf` | ❌ | — | — |  | |
-| `--owner` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  | |
-| `--partial` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  | |
-| `--partial-dir` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  | |
-| `--password-file` | ✅ | ❌ | [tests/daemon.rs](../tests/daemon.rs) |  | |
-| `--perms` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  | |
-| `--port` | ❌ | — | — |  | |
-| `--preallocate` | ❌ | — | — |  | |
-| `--progress` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  | |
-| `--protocol` | ❌ | — | — |  | |
-| `--prune-empty-dirs` | ❌ | — | — |  | |
-| `--quiet` | ✅ | ✅ | [tests/golden/cli_parity/compression.sh](../tests/golden/cli_parity/compression.sh)<br>[tests/golden/cli_parity/delete.sh](../tests/golden/cli_parity/delete.sh)<br>[tests/golden/cli_parity/selection.sh](../tests/golden/cli_parity/selection.sh) |  | |
-| `--read-batch` | ❌ | — | — |  | |
-| `--recursive` | ✅ | ✅ | [tests/golden/cli_parity/delete.sh](../tests/golden/cli_parity/delete.sh)<br>[tests/golden/cli_parity/compression.sh](../tests/golden/cli_parity/compression.sh)<br>[tests/golden/cli_parity/selection.sh](../tests/golden/cli_parity/selection.sh) |  | |
-| `--relative` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  | |
-| `--remote-option` | ❌ | — | — |  | |
-| `--remove-source-files` | ❌ | — | — |  | |
-| `--rsh` | ❌ | — | [tests/rsh.rs](../tests/rsh.rs) |  | |
-| `--rsync-path` | ❌ | — | [tests/rsync_path.rs](../tests/rsync_path.rs) |  | |
-| `--safe-links` | ❌ | — | — |  | |
-| `--secluded-args` | ❌ | — | — |  | |
-| `--secrets-file` | ✅ | ❌ | [tests/daemon.rs](../tests/daemon.rs) |  | |
-| `--server` | ✅ | ❌ | [tests/server.rs](../tests/server.rs) | negotiates protocol version and codecs | |
-| `--size-only` | ❌ | — | — |  | |
-| `--skip-compress` | ❌ | — | — |  | |
-| `--sockopts` | ❌ | — | — |  | |
-| `--sparse` | ✅ | ✅ | [tests/cli.rs](../tests/cli.rs) | creates holes for long zero runs | |
-| `--specials` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  | |
-| `--stats` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  | |
-| `--stderr` | ❌ | — | — |  | |
-| `--stop-after` | ❌ | — | — |  | |
-| `--stop-at` | ❌ | — | — |  | |
-| `--suffix` | ❌ | — | — |  | |
-| `--super` | ❌ | — | — |  | |
-| `--temp-dir` | ❌ | — | — |  | |
-| `--timeout` | ❌ | — | — |  | |
-| `--times` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  | |
-| `--trust-sender` | ❌ | — | — |  | |
-| `--update` | ❌ | — | — |  | |
-| `--usermap` | ❌ | — | — |  | |
-| `--verbose` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  | |
-| `--version` | ❌ | — | — |  | |
-| `--whole-file` | ❌ | — | — |  | |
-| `--write-batch` | ❌ | — | — |  | |
-| `--write-devices` | ❌ | — | — |  | |
-| `--xattrs` | ✅ | ❌ | [tests/local_sync_tree.rs](../tests/local_sync_tree.rs)<br>[tests/daemon_sync_attrs.rs](../tests/daemon_sync_attrs.rs) | requires `xattr` feature | |
+| Option | Short | Supported | Parity | Default | Interactions | Tests | Notes | Enhanced? |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `--8-bit-output` | `-8` | ❌ | — | off | — | — |  |  |
+| `--acls` | `-A` | ✅ | ❌ | off | requires `acl` feature | [tests/local_sync_tree.rs](../tests/local_sync_tree.rs)<br>[tests/daemon_sync_attrs.rs](../tests/daemon_sync_attrs.rs) | requires `acl` feature |  |
+| `--address` | — | ❌ | — | — | — | — |  |  |
+| `--append` | — | ❌ | — | off | — | — |  |  |
+| `--append-verify` | — | ❌ | — | off | — | — |  |  |
+| `--archive` | `-a` | ✅ | ❌ | off | — | [tests/interop/run_matrix.sh](../tests/interop/run_matrix.sh) |  |  |
+| `--atimes` | `-U` | ❌ | — | off | — | — |  |  |
+| `--backup` | `-b` | ❌ | — | off | — | — |  |  |
+| `--backup-dir` | — | ❌ | — | — | — | — |  |  |
+| `--block-size` | `-B` | ❌ | — | — | — | — |  |  |
+| `--blocking-io` | — | ❌ | — | off | — | — |  |  |
+| `--bwlimit` | — | ❌ | — | — | — | — |  |  |
+| `--cc` | — | ❌ | — | off | alias for `--checksum-choice` | [gaps.md](gaps.md) | alias for `--checksum-choice` |  |
+| `--checksum` | `-c` | ✅ | ✅ | off | — | [tests/cli.rs](../tests/cli.rs) | strong hashes: MD5 (default), SHA-1, BLAKE3 |  |
+| `--checksum-choice` | — | ❌ | — | — | choose the checksum algorithm (aka --cc) | — |  |  |
+| `--checksum-seed` | — | ❌ | — | — | — | — |  |  |
+| `--chmod` | — | ❌ | — | — | — | — |  |  |
+| `--chown` | — | ❌ | — | — | — | — |  |  |
+| `--compare-dest` | — | ❌ | — | — | — | — |  |  |
+| `--compress` | `-z` | ✅ | ✅ | off | — | [tests/golden/cli_parity/compression.sh](../tests/golden/cli_parity/compression.sh)<br>[tests/compression_negotiation.sh](../tests/compression_negotiation.sh) | negotiates zstd when supported by both peers |  |
+| `--compress-choice` | — | ❌ | — | — | choose the compression algorithm (aka --zc) | — |  |  |
+| `--compress-level` | — | ✅ | ❌ | — | explicitly set compression level (aka --zl) | [tests/golden/cli_parity/compress-level.sh](../tests/golden/cli_parity/compress-level.sh) |  |  |
+| `--zc` | — | ❌ | — | off | alias for `--compress-choice` | [gaps.md](gaps.md) | alias for `--compress-choice` |  |
+| `--zl` | — | ❌ | — | off | alias for `--compress-level` | [gaps.md](gaps.md) | alias for `--compress-level` |  |
+| `--contimeout` | — | ❌ | — | — | — | — |  |  |
+| `--copy-as` | — | ❌ | — | — | — | — |  |  |
+| `--copy-dest` | — | ❌ | — | — | — | — |  |  |
+| `--copy-devices` | — | ❌ | — | off | — | — |  |  |
+| `--copy-dirlinks` | `-k` | ❌ | — | off | — | — |  |  |
+| `--copy-links` | `-L` | ❌ | — | off | — | — |  |  |
+| `--copy-unsafe-links` | — | ❌ | — | off | — | — |  |  |
+| `--crtimes` | `-N` | ❌ | — | off | — | — |  |  |
+| `--cvs-exclude` | `-C` | ❌ | — | off | — | — |  |  |
+| `--daemon` | — | ✅ | ❌ | off | — | [tests/daemon.rs](../tests/daemon.rs) |  |  |
+| `--debug` | — | ❌ | — | — | — | — |  |  |
+| `--del` | — | ✅ | ✅ | off | an alias for --delete-during | [tests/golden/cli_parity/delete.sh](../tests/golden/cli_parity/delete.sh) | alias for `--delete-during` |  |
+| `--delay-updates` | — | ❌ | — | off | — | — |  |  |
+| `--delete` | — | ✅ | ✅ | off | — | [tests/golden/cli_parity/delete.sh](../tests/golden/cli_parity/delete.sh) |  |  |
+| `--delete-after` | — | ✅ | ✅ | off | — | [tests/golden/cli_parity/delete.sh](../tests/golden/cli_parity/delete.sh) |  |  |
+| `--delete-before` | — | ✅ | ✅ | off | — | [tests/golden/cli_parity/delete.sh](../tests/golden/cli_parity/delete.sh) |  |  |
+| `--delete-delay` | — | ✅ | ❌ | off | — | [tests/cli.rs](../tests/cli.rs) |  |  |
+| `--delete-during` | — | ✅ | ✅ | off | — | [tests/golden/cli_parity/delete.sh](../tests/golden/cli_parity/delete.sh) |  |  |
+| `--delete-excluded` | — | ❌ | — | off | — | — |  |  |
+| `--delete-missing-args` | — | ❌ | — | off | — | — |  |  |
+| `--devices` | — | ✅ | ❌ | off | — | [tests/local_sync_tree.rs](../tests/local_sync_tree.rs) |  |  |
+| `--dirs` | `-d` | ❌ | — | off | — | — |  |  |
+| `--dry-run` | `-n` | ✅ | ❌ | off | — | [tests/cli.rs](../tests/cli.rs) |  |  |
+| `--early-input` | — | ❌ | — | — | — | — |  |  |
+| `--exclude` | — | ✅ | ❌ | — | — | [tests/cli.rs](../tests/cli.rs) |  |  |
+| `--exclude-from` | — | ✅ | ❌ | — | — | [tests/cli.rs](../tests/cli.rs) |  |  |
+| `--executability` | `-E` | ❌ | — | off | — | — |  |  |
+| `--existing` | — | ❌ | — | off | — | — |  |  |
+| `--fake-super` | — | ❌ | — | off | — | — |  |  |
+| `--files-from` | — | ✅ | ❌ | — | — | [tests/cli.rs](../tests/cli.rs) |  |  |
+| `--filter` | `-f` | ✅ | ✅ | — | — | [tests/golden/cli_parity/selection.sh](../tests/golden/cli_parity/selection.sh) |  |  |
+| `--force` | — | ❌ | — | off | — | — |  |  |
+| `--from0` | `-0` | ✅ | ❌ | off | — | [tests/cli.rs](../tests/cli.rs) |  |  |
+| `--fsync` | — | ❌ | — | off | — | — |  |  |
+| `--fuzzy` | `-y` | ❌ | — | off | — | — |  |  |
+| `--group` | `-g` | ✅ | ❌ | off | — | [tests/cli.rs](../tests/cli.rs) |  |  |
+| `--groupmap` | — | ❌ | — | — | — | — |  |  |
+| `--hard-links` | `-H` | ✅ | ❌ | off | — | [tests/local_sync_tree.rs](../tests/local_sync_tree.rs) |  |  |
+| `--help` | `-h (*)` | ✅ | ❌ | off | — | [tests/cli.rs](../tests/cli.rs) |  |  |
+| `--human-readable` | `-h` | ❌ | — | off | — | — |  |  |
+| `--iconv` | — | ❌ | — | — | — | — |  |  |
+| `--ignore-errors` | — | ❌ | — | off | — | — |  |  |
+| `--ignore-existing` | — | ❌ | — | off | — | — |  |  |
+| `--ignore-missing-args` | — | ❌ | — | off | — | — |  |  |
+| `--ignore-times` | `-I` | ❌ | — | off | — | — |  |  |
+| `--include` | — | ✅ | ❌ | — | — | [tests/cli.rs](../tests/cli.rs) |  |  |
+| `--include-from` | — | ✅ | ❌ | — | — | [tests/cli.rs](../tests/cli.rs) |  |  |
+| `--info` | — | ❌ | — | — | — | — |  |  |
+| `--inplace` | — | ✅ | ✅ | off | — | [tests/golden/cli_parity/inplace.sh](../tests/golden/cli_parity/inplace.sh) |  |  |
+| `--ipv4` | `-4` | ❌ | — | off | — | — |  |  |
+| `--ipv6` | `-6` | ❌ | — | off | — | — |  |  |
+| `--itemize-changes` | `-i` | ❌ | — | off | — | — |  |  |
+| `--keep-dirlinks` | `-K` | ❌ | — | off | — | — |  |  |
+| `--link-dest` | — | ❌ | — | — | — | — |  |  |
+| `--links` | `-l` | ✅ | ❌ | off | — | [tests/cli.rs](../tests/cli.rs) |  |  |
+| `--list-only` | — | ❌ | — | off | — | — |  |  |
+| `--log-file` | — | ❌ | — | — | — | — |  |  |
+| `--log-file-format` | — | ❌ | — | — | — | — |  |  |
+| `--max-alloc` | — | ❌ | — | — | — | — |  |  |
+| `--max-delete` | — | ❌ | — | — | — | — |  |  |
+| `--max-size` | — | ❌ | — | — | — | — |  |  |
+| `--min-size` | — | ❌ | — | — | — | — |  |  |
+| `--mkpath` | — | ❌ | — | off | — | — |  |  |
+| `--modify-window` | `-@` | ❌ | — | — | — | — |  |  |
+| `--munge-links` | — | ❌ | — | off | — | — |  |  |
+| `--no-D` | — | ❌ | — | off | alias for `--no-devices --no-specials` | [gaps.md](gaps.md) | alias for `--no-devices --no-specials` |  |
+| `--no-OPTION` | — | ❌ | — | off | — | — |  |  |
+| `--no-implied-dirs` | — | ❌ | — | off | — | — |  |  |
+| `--no-motd` | — | ❌ | — | off | — | — |  |  |
+| `--numeric-ids` | — | ✅ | ❌ | off | — | [tests/cli.rs](../tests/cli.rs) |  |  |
+| `--old-args` | — | ❌ | — | off | — | — |  |  |
+| `--old-d` | — | ❌ | — | off | alias for --old-dirs | [gaps.md](gaps.md) | alias for `--old-dirs` |  |
+| `--old-dirs` | — | ❌ | — | off | — | — |  |  |
+| `--omit-dir-times` | `-O` | ❌ | — | off | — | — |  |  |
+| `--omit-link-times` | `-J` | ❌ | — | off | — | — |  |  |
+| `--one-file-system` | `-x` | ❌ | — | off | — | — |  |  |
+| `--only-write-batch` | — | ❌ | — | — | — | — |  |  |
+| `--open-noatime` | — | ❌ | — | off | — | — |  |  |
+| `--out-format` | — | ❌ | — | — | — | — |  |  |
+| `--outbuf` | — | ❌ | — | — | — | — |  |  |
+| `--owner` | `-o` | ✅ | ❌ | off | — | [tests/cli.rs](../tests/cli.rs) |  |  |
+| `--partial` | — | ✅ | ❌ | off | — | [tests/cli.rs](../tests/cli.rs) |  |  |
+| `--partial-dir` | — | ✅ | ❌ | — | — | [tests/cli.rs](../tests/cli.rs) |  |  |
+| `--password-file` | — | ✅ | ❌ | — | — | [tests/daemon.rs](../tests/daemon.rs) |  |  |
+| `--perms` | `-p` | ✅ | ❌ | off | — | [tests/cli.rs](../tests/cli.rs) |  |  |
+| `--port` | — | ❌ | — | — | — | — |  |  |
+| `--preallocate` | — | ❌ | — | off | — | — |  |  |
+| `--progress` | — | ✅ | ❌ | off | — | [tests/cli.rs](../tests/cli.rs) |  |  |
+| `--protocol` | — | ❌ | — | — | — | — |  |  |
+| `--prune-empty-dirs` | `-m` | ❌ | — | off | — | — |  |  |
+| `--quiet` | `-q` | ✅ | ✅ | off | — | [tests/golden/cli_parity/compression.sh](../tests/golden/cli_parity/compression.sh)<br>[tests/golden/cli_parity/delete.sh](../tests/golden/cli_parity/delete.sh)<br>[tests/golden/cli_parity/selection.sh](../tests/golden/cli_parity/selection.sh) |  |  |
+| `--read-batch` | — | ❌ | — | — | — | — |  |  |
+| `--recursive` | `-r` | ✅ | ✅ | off | — | [tests/golden/cli_parity/delete.sh](../tests/golden/cli_parity/delete.sh)<br>[tests/golden/cli_parity/compression.sh](../tests/golden/cli_parity/compression.sh)<br>[tests/golden/cli_parity/selection.sh](../tests/golden/cli_parity/selection.sh) |  |  |
+| `--relative` | `-R` | ✅ | ❌ | off | — | [tests/cli.rs](../tests/cli.rs) |  |  |
+| `--remote-option` | `-M` | ❌ | — | — | — | — |  |  |
+| `--remove-source-files` | — | ❌ | — | off | — | — |  |  |
+| `--rsh` | `-e` | ❌ | — | — | — | [tests/rsh.rs](../tests/rsh.rs) |  |  |
+| `--rsync-path` | — | ❌ | — | — | — | [tests/rsync_path.rs](../tests/rsync_path.rs) |  |  |
+| `--safe-links` | — | ❌ | — | off | — | — |  |  |
+| `--secluded-args` | `-s` | ❌ | — | off | — | — |  |  |
+| `--secrets-file` | — | ✅ | ❌ | off | — | [tests/daemon.rs](../tests/daemon.rs) |  |  |
+| `--server` | — | ✅ | ❌ | off | — | [tests/server.rs](../tests/server.rs) | negotiates protocol version and codecs |  |
+| `--size-only` | — | ❌ | — | off | — | — |  |  |
+| `--skip-compress` | — | ❌ | — | — | — | — |  |  |
+| `--sockopts` | — | ❌ | — | — | — | — |  |  |
+| `--sparse` | `-S` | ✅ | ✅ | off | — | [tests/cli.rs](../tests/cli.rs) | creates holes for long zero runs |  |
+| `--specials` | — | ✅ | ❌ | off | — | [tests/cli.rs](../tests/cli.rs) |  |  |
+| `--stats` | — | ✅ | ❌ | off | — | [tests/cli.rs](../tests/cli.rs) |  |  |
+| `--stderr` | — | ❌ | — | errors | — | — |  |  |
+| `--stop-after` | — | ❌ | — | — | — | — |  |  |
+| `--stop-at` | — | ❌ | — | — | — | — |  |  |
+| `--suffix` | — | ❌ | — | ~ w/o --backup-dir | — | — |  |  |
+| `--super` | — | ❌ | — | off | — | — |  |  |
+| `--temp-dir` | `-T` | ❌ | — | — | — | — |  |  |
+| `--timeout` | — | ❌ | — | — | — | — |  |  |
+| `--times` | `-t` | ✅ | ❌ | off | — | [tests/cli.rs](../tests/cli.rs) |  |  |
+| `--trust-sender` | — | ❌ | — | off | — | — |  |  |
+| `--update` | `-u` | ❌ | — | off | — | — |  |  |
+| `--usermap` | — | ❌ | — | — | — | — |  |  |
+| `--verbose` | `-v` | ✅ | ❌ | off | — | [tests/cli.rs](../tests/cli.rs) |  |  |
+| `--version` | `-V` | ❌ | — | off | — | — |  |  |
+| `--whole-file` | `-W` | ❌ | — | off | — | — |  |  |
+| `--write-batch` | — | ❌ | — | — | — | — |  |  |
+| `--write-devices` | — | ❌ | — | off | — | — |  |  |
+| `--xattrs` | `-X` | ✅ | ❌ | off | requires `xattr` feature | [tests/local_sync_tree.rs](../tests/local_sync_tree.rs)<br>[tests/daemon_sync_attrs.rs](../tests/daemon_sync_attrs.rs) | requires `xattr` feature |  |

--- a/tools/flag_matrix.json
+++ b/tools/flag_matrix.json
@@ -6,8 +6,8 @@
   },
   {
     "flag": "--acls",
-    "status": "Ok",
-    "notes": "requires acl feature"
+    "status": "Error",
+    "notes": ""
   },
   {
     "flag": "--address",
@@ -341,7 +341,7 @@
   },
   {
     "flag": "--inplace",
-    "status": "Error",
+    "status": "Supported",
     "notes": ""
   },
   {
@@ -706,8 +706,8 @@
   },
   {
     "flag": "--xattrs",
-    "status": "Ok",
-    "notes": "requires xattr feature"
+    "status": "Error",
+    "notes": ""
   },
   {
     "flag": "-0",
@@ -736,7 +736,7 @@
   },
   {
     "flag": "-A",
-    "status": "Ok",
+    "status": "Error",
     "notes": "alias for --acls"
   },
   {
@@ -771,7 +771,7 @@
   },
   {
     "flag": "-I",
-    "status": "Error",
+    "status": "Alias",
     "notes": "alias for --ignore-times"
   },
   {
@@ -841,7 +841,7 @@
   },
   {
     "flag": "-X",
-    "status": "Ok",
+    "status": "Error",
     "notes": "alias for --xattrs"
   },
   {

--- a/tools/flag_matrix.md
+++ b/tools/flag_matrix.md
@@ -1,7 +1,7 @@
 | flag | status | notes |
 | --- | --- | --- |
 | --8-bit-output | Error |  |
-| --acls | Ok | requires acl feature |
+| --acls | Error |  |
 | --address | Error |  |
 | --append | Error |  |
 | --append-verify | Error |  |
@@ -68,7 +68,7 @@
 | --include | Supported |  |
 | --include-from | Supported |  |
 | --info | Error |  |
-| --inplace | Error |  |
+| --inplace | Supported |  |
 | --ipv4 | Error |  |
 | --ipv6 | Error |  |
 | --itemize-changes | Error |  |
@@ -141,20 +141,20 @@
 | --whole-file | Error |  |
 | --write-batch | Error |  |
 | --write-devices | Error |  |
-| --xattrs | Ok | requires xattr feature |
+| --xattrs | Error |  |
 | -0 | Error | alias for --from0 |
 | -4 | Error | alias for --ipv4 |
 | -6 | Error | alias for --ipv6 |
 | -8 | Error | alias for --8-bit-output |
 | -@ | Error | alias for --modify-window |
-| -A | Ok | alias for --acls |
+| -A | Error | alias for --acls |
 | -B | Error | alias for --block-size |
 | -C | Error | alias for --cvs-exclude |
 | -D | Error | same as --devices --specials |
 | -E | Error | alias for --executability |
 | -F | Error | same as --filter='dir-merge /.rsync-filter' |
 | -H | Error | alias for --hard-links |
-| -I | Error | alias for --ignore-times |
+| -I | Alias | alias for --ignore-times |
 | -J | Error | alias for --omit-link-times |
 | -K | Error | alias for --keep-dirlinks |
 | -L | Error | alias for --copy-links |
@@ -168,7 +168,7 @@
 | -U | Error | alias for --atimes |
 | -V | Error | alias for --version |
 | -W | Error | alias for --whole-file |
-| -X | Ok | alias for --xattrs |
+| -X | Error | alias for --xattrs |
 | -a | Alias | alias for --archive |
 | -b | Error | alias for --backup |
 | -c | Alias | alias for --checksum |


### PR DESCRIPTION
## Summary
- add Short, Default, and Interactions columns to feature matrix
- regenerate flag matrix tooling

## Testing
- `cargo run --quiet --bin flag_matrix`
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_68b1698d847c83238df7ddff6c198296