### PR TITLE
cli: allow custom remote binary

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -359,6 +359,7 @@ fn spawn_remote_session(
     host: &str,
     path: &Path,
     rsh: &[String],
+    remote_bin: Option<&Path>,
     known_hosts: Option<&Path>,
     strict_host_key_checking: bool,
 ) -> io::Result<SshStdioTransport> {
@@ -389,14 +390,22 @@ fn spawn_remote_session(
                     .arg(format!("UserKnownHostsFile={}", path.display()));
             }
             cmd.arg(host);
-            cmd.arg("rsync");
+            if let Some(bin) = remote_bin {
+                cmd.arg(bin);
+            } else {
+                cmd.arg("rsync");
+            }
             cmd.arg("--server");
             cmd.arg(path.as_os_str());
             SshStdioTransport::spawn_from_command(cmd)
         } else {
             let mut args = rsh[1..].to_vec();
             args.push(host.to_string());
-            args.push("rsync".to_string());
+            if let Some(bin) = remote_bin {
+                args.push(bin.to_string_lossy().into_owned());
+            } else {
+                args.push("rsync".to_string());
+            }
             args.push("--server".to_string());
             args.push(path.to_string_lossy().into_owned());
             SshStdioTransport::spawn(program, args)
@@ -613,6 +622,7 @@ fn run_client(opts: ClientOpts) -> Result<()> {
                     &host,
                     &src.path,
                     &rsh_cmd,
+                    opts.rsync_path.as_deref(),
                     known_hosts.as_deref(),
                     strict_host_key_checking,
                 )
@@ -629,6 +639,7 @@ fn run_client(opts: ClientOpts) -> Result<()> {
                     &host,
                     &dst.path,
                     &rsh_cmd,
+                    opts.rsync_path.as_deref(),
                     known_hosts.as_deref(),
                     strict_host_key_checking,
                 )
@@ -661,6 +672,7 @@ fn run_client(opts: ClientOpts) -> Result<()> {
                     &dst_host,
                     &dst_path.path,
                     &rsh_cmd,
+                    opts.rsync_path.as_deref(),
                     known_hosts.as_deref(),
                     strict_host_key_checking,
                 )
@@ -669,6 +681,7 @@ fn run_client(opts: ClientOpts) -> Result<()> {
                     &src_host,
                     &src_path.path,
                     &rsh_cmd,
+                    opts.rsync_path.as_deref(),
                     known_hosts.as_deref(),
                     strict_host_key_checking,
                 )

--- a/tests/rsync_path.rs
+++ b/tests/rsync_path.rs
@@ -1,3 +1,45 @@
+use assert_cmd::Command;
+use std::fs;
+use tempfile::tempdir;
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+
+#[cfg(unix)]
 #[test]
-#[ignore = "placeholder for --rsync-path option"]
-fn rsync_path_option_placeholder() {}
+fn custom_rsync_path_performs_transfer() {
+    let dir = tempdir().unwrap();
+    let src_dir = dir.path().join("src");
+    fs::create_dir(&src_dir).unwrap();
+    let src_file = src_dir.join("file.txt");
+    fs::write(&src_file, b"from custom binary").unwrap();
+    let dst_dir = dir.path().join("dst");
+
+    // Copy the client binary to act as the remote rsync executable.
+    let remote_bin = dir.path().join("rr-remote");
+    fs::copy(assert_cmd::cargo::cargo_bin("rsync-rs"), &remote_bin).unwrap();
+    let mut perms = fs::metadata(&remote_bin).unwrap().permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(&remote_bin, perms).unwrap();
+
+    // Create a fake remote shell that ignores the host argument.
+    let rsh = dir.path().join("fake_rsh.sh");
+    fs::write(&rsh, b"#!/bin/sh\nshift\nexec \"$@\"\n").unwrap();
+    fs::set_permissions(&rsh, fs::Permissions::from_mode(0o755)).unwrap();
+
+    let src_spec = format!("{}/", src_dir.display());
+    let dst_spec = format!("ignored:{}", dst_dir.display());
+    let mut cmd = Command::cargo_bin("rsync-rs").unwrap();
+    cmd.args([
+        "-e",
+        rsh.to_str().unwrap(),
+        "--rsync-path",
+        remote_bin.to_str().unwrap(),
+        "-r",
+        &src_spec,
+        &dst_spec,
+    ]);
+    cmd.assert().success();
+
+    let out = fs::read(dst_dir.join("file.txt")).unwrap();
+    assert_eq!(out, b"from custom binary");
+}


### PR DESCRIPTION
## Summary
- allow `spawn_remote_session` to run a specified remote binary
- wire `--rsync-path` option into remote session spawning
- add integration test for `--rsync-path` using a custom binary

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b16a78220883238f55947a5042f14f