### PR TITLE
Implement append flags and resumable transfers

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -136,6 +136,12 @@ struct ClientOpts {
     /// keep partially transferred files and show progress
     #[arg(short = 'P', help_heading = "Misc")]
     partial_progress: bool,
+    /// append data onto shorter files
+    #[arg(long, help_heading = "Misc")]
+    append: bool,
+    /// --append with old data verification
+    #[arg(long = "append-verify", help_heading = "Misc")]
+    append_verify: bool,
     /// update destination files in-place
     #[arg(short = 'I', long, help_heading = "Misc")]
     inplace: bool,
@@ -587,6 +593,8 @@ fn run_client(opts: ClientOpts) -> Result<()> {
         partial: opts.partial || opts.partial_progress,
         progress: opts.progress || opts.partial_progress,
         partial_dir: opts.partial_dir.clone(),
+        append: opts.append,
+        append_verify: opts.append_verify,
         numeric_ids: opts.numeric_ids,
         inplace: opts.inplace,
         bwlimit: opts.bwlimit,

--- a/tests/resume.rs
+++ b/tests/resume.rs
@@ -1,0 +1,136 @@
+use assert_cmd::prelude::*;
+use std::process::Command;
+use std::thread;
+use std::time::Duration;
+use tempfile::tempdir;
+
+#[test]
+fn partial_transfer_resumes_after_interrupt() {
+    let dir = tempdir().unwrap();
+    let src_dir = dir.path().join("src");
+    let dst_dir = dir.path().join("dst");
+    std::fs::create_dir_all(&src_dir).unwrap();
+    std::fs::create_dir_all(&dst_dir).unwrap();
+    let data = vec![b'a'; 200_000];
+    std::fs::write(src_dir.join("a.txt"), &data).unwrap();
+
+    let src_arg = format!("{}/", src_dir.display());
+    let mut child = Command::cargo_bin("rsync-rs")
+        .unwrap()
+        .args([
+            "--local",
+            "--partial",
+            "--bwlimit",
+            "10240",
+            &src_arg,
+            dst_dir.to_str().unwrap(),
+        ])
+        .spawn()
+        .unwrap();
+    thread::sleep(Duration::from_millis(100));
+    let _ = child.kill();
+    let _ = child.wait();
+
+    assert!(dst_dir.join("a.partial").exists());
+
+    let mut cmd = Command::cargo_bin("rsync-rs").unwrap();
+    cmd.args([
+        "--local",
+        "--partial",
+        &src_arg,
+        dst_dir.to_str().unwrap(),
+    ]);
+    cmd.assert().success();
+
+    let out = std::fs::read(dst_dir.join("a.txt")).unwrap();
+    assert_eq!(out, data);
+}
+
+#[test]
+fn append_resumes_after_interrupt() {
+    let dir = tempdir().unwrap();
+    let src_dir = dir.path().join("src");
+    let dst_dir = dir.path().join("dst");
+    std::fs::create_dir_all(&src_dir).unwrap();
+    std::fs::create_dir_all(&dst_dir).unwrap();
+    let data = vec![b'b'; 200_000];
+    std::fs::write(src_dir.join("a.txt"), &data).unwrap();
+
+    let src_arg = format!("{}/", src_dir.display());
+    let mut child = Command::cargo_bin("rsync-rs")
+        .unwrap()
+        .args([
+            "--local",
+            "--bwlimit",
+            "10240",
+            &src_arg,
+            dst_dir.to_str().unwrap(),
+        ])
+        .spawn()
+        .unwrap();
+    thread::sleep(Duration::from_millis(100));
+    let _ = child.kill();
+    let _ = child.wait();
+
+    let dest_file = dst_dir.join("a.txt");
+    assert!(dest_file.exists());
+
+    let mut cmd = Command::cargo_bin("rsync-rs").unwrap();
+    cmd.args([
+        "--local",
+        "--append",
+        &src_arg,
+        dst_dir.to_str().unwrap(),
+    ]);
+    cmd.assert().success();
+
+    let out = std::fs::read(dest_file).unwrap();
+    assert_eq!(out, data);
+}
+
+#[test]
+fn append_verify_restarts_on_mismatch() {
+    let dir = tempdir().unwrap();
+    let src_dir = dir.path().join("src");
+    let dst_dir = dir.path().join("dst");
+    std::fs::create_dir_all(&src_dir).unwrap();
+    std::fs::create_dir_all(&dst_dir).unwrap();
+    let data = vec![b'c'; 200_000];
+    std::fs::write(src_dir.join("a.txt"), &data).unwrap();
+
+    let src_arg = format!("{}/", src_dir.display());
+    let mut child = Command::cargo_bin("rsync-rs")
+        .unwrap()
+        .args([
+            "--local",
+            "--bwlimit",
+            "10240",
+            &src_arg,
+            dst_dir.to_str().unwrap(),
+        ])
+        .spawn()
+        .unwrap();
+    thread::sleep(Duration::from_millis(100));
+    let _ = child.kill();
+    let _ = child.wait();
+
+    let dest_file = dst_dir.join("a.txt");
+    let mut partial = std::fs::read(&dest_file).unwrap();
+    if !partial.is_empty() {
+        partial[0] ^= 1;
+        std::fs::write(&dest_file, &partial).unwrap();
+    }
+
+    let mut cmd = Command::cargo_bin("rsync-rs").unwrap();
+    cmd.args([
+        "--local",
+        "--append-verify",
+        &src_arg,
+        dst_dir.to_str().unwrap(),
+    ]);
+    cmd.assert().success();
+
+    let out = std::fs::read(dest_file).unwrap();
+    assert_eq!(out, data);
+}
+


### PR DESCRIPTION
## Summary
- support `--append` and `--append-verify` in CLI and engine
- resume transfers from partial files or existing destinations
- add regression tests for partial resume and append logic

## Testing
- `cargo +stable test`

------
https://chatgpt.com/codex/tasks/task_e_68b18a84441c8323b9b7ff5e70560f95