### PR TITLE
Prevent recursive parsing of filter files

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::env;
 use std::fs::{self, OpenOptions};
 use std::io::{self, Read, Write};
@@ -10,10 +10,15 @@ use std::path::{Path, PathBuf};
 use clap::{ArgAction, ArgMatches, CommandFactory, FromArgMatches, Parser};
 use compress::{available_codecs, Codec};
 use engine::{sync, DeleteMode, EngineError, Result, Stats, StrongHash, SyncOptions};
-use filters::{parse as parse_filters, Matcher, Rule};
+use filters::{parse, Matcher, Rule};
 use protocol::{negotiate_version, LATEST_VERSION};
 use shell_words::split as shell_split;
 use transport::{RateLimitedTransport, SshStdioTransport, TcpTransport, Transport};
+
+fn parse_filters(s: &str) -> std::result::Result<Vec<Rule>, filters::ParseError> {
+    let mut v = HashSet::new();
+    parse(s, &mut v, 0)
+}
 
 /// Command line interface for rsync-rs.
 ///

--- a/crates/engine/tests/filter.rs
+++ b/crates/engine/tests/filter.rs
@@ -1,6 +1,7 @@
 use compress::available_codecs;
 use engine::{sync, SyncOptions};
 use filters::{parse, Matcher};
+use std::collections::HashSet;
 use std::fs;
 use tempfile::tempdir;
 
@@ -13,7 +14,8 @@ fn excluded_paths_are_skipped() {
     fs::write(src.join("include.txt"), b"include").unwrap();
     fs::write(src.join("skip.txt"), b"skip").unwrap();
 
-    let rules = parse("- skip.txt").unwrap();
+    let mut visited = HashSet::new();
+    let rules = parse("- skip.txt", &mut visited, 0).unwrap();
     let matcher = Matcher::new(rules);
 
     sync(

--- a/crates/filters/tests/anchored_wildcards.rs
+++ b/crates/filters/tests/anchored_wildcards.rs
@@ -1,8 +1,14 @@
 use filters::{parse, Matcher};
+use std::collections::HashSet;
+
+fn p(input: &str) -> Vec<filters::Rule> {
+    let mut v = HashSet::new();
+    parse(input, &mut v, 0).unwrap()
+}
 
 #[test]
 fn root_anchored_exclusion() {
-    let rules = parse("- /root.txt\n+ *.txt\n- *\n").unwrap();
+    let rules = p("- /root.txt\n+ *.txt\n- *\n");
     let matcher = Matcher::new(rules);
     assert!(!matcher.is_included("root.txt").unwrap());
     assert!(matcher.is_included("dir/root.txt").unwrap());
@@ -10,7 +16,7 @@ fn root_anchored_exclusion() {
 
 #[test]
 fn directory_trailing_slash() {
-    let rules = parse("- tmp/\n").unwrap();
+    let rules = p("- tmp/\n");
     let matcher = Matcher::new(rules);
     assert!(!matcher.is_included("tmp").unwrap());
     assert!(!matcher.is_included("tmp/file.txt").unwrap());
@@ -19,7 +25,7 @@ fn directory_trailing_slash() {
 
 #[test]
 fn wildcard_question_mark() {
-    let rules = parse("+ file?.txt\n- *\n").unwrap();
+    let rules = p("+ file?.txt\n- *\n");
     let matcher = Matcher::new(rules);
     assert!(matcher.is_included("file1.txt").unwrap());
     assert!(!matcher.is_included("file10.txt").unwrap());
@@ -27,7 +33,7 @@ fn wildcard_question_mark() {
 
 #[test]
 fn double_star_matches() {
-    let rules = parse("+ dir/**/keep.txt\n- *\n").unwrap();
+    let rules = p("+ dir/**/keep.txt\n- *\n");
     let matcher = Matcher::new(rules);
     assert!(matcher.is_included("dir/a/b/keep.txt").unwrap());
     assert!(!matcher.is_included("dir/a/b/drop.txt").unwrap());

--- a/crates/filters/tests/comments.rs
+++ b/crates/filters/tests/comments.rs
@@ -1,9 +1,15 @@
 use filters::{parse, Matcher};
+use std::collections::HashSet;
+
+fn p(input: &str) -> Vec<filters::Rule> {
+    let mut v = HashSet::new();
+    parse(input, &mut v, 0).unwrap()
+}
 
 #[test]
 fn comments_and_blank_lines_are_ignored() {
     // Leading comment and blank line should be ignored by the parser
-    let rules = parse("# initial comment\n\n+ keep.log\n- *.log\n").expect("parse");
+    let rules = p("# initial comment\n\n+ keep.log\n- *.log\n");
     let matcher = Matcher::new(rules);
 
     assert!(matcher.is_included("keep.log").unwrap());

--- a/crates/filters/tests/files_from.rs
+++ b/crates/filters/tests/files_from.rs
@@ -1,9 +1,15 @@
 use filters::parse;
 use filters::Matcher;
+use std::collections::HashSet;
+
+fn p(s: &str) -> Vec<filters::Rule> {
+    let mut v = HashSet::new();
+    parse(s, &mut v, 0).unwrap()
+}
 
 #[test]
 fn files_from_emulation() {
-    let rules = parse("+ foo\n+ bar\n- *\n").expect("parse");
+    let rules = p("+ foo\n+ bar\n- *\n");
     let matcher = Matcher::new(rules);
     assert!(matcher.is_included("foo").unwrap());
     assert!(matcher.is_included("bar").unwrap());
@@ -19,9 +25,9 @@ fn files_from_null_separated() {
             continue;
         }
         let pat = String::from_utf8_lossy(part);
-        rules.extend(parse(&format!("+ {}\n", pat)).unwrap());
+        rules.extend(p(&format!("+ {}\n", pat)));
     }
-    rules.extend(parse("- *\n").unwrap());
+    rules.extend(p("- *\n"));
     let matcher = Matcher::new(rules);
     assert!(matcher.is_included("foo").unwrap());
     assert!(matcher.is_included("bar").unwrap());

--- a/crates/filters/tests/include_exclude.rs
+++ b/crates/filters/tests/include_exclude.rs
@@ -1,9 +1,15 @@
 use filters::{parse, Matcher};
 use proptest::prelude::*;
+use std::collections::HashSet;
+
+fn p(s: &str) -> Vec<filters::Rule> {
+    let mut v = HashSet::new();
+    parse(s, &mut v, 0).unwrap()
+}
 
 #[test]
 fn include_and_exclude() {
-    let rules = parse("+ special.tmp\n- *.tmp\n").expect("parse");
+    let rules = p("+ special.tmp\n- *.tmp\n");
     let matcher = Matcher::new(rules);
 
     assert!(matcher.is_included("special.tmp").unwrap());
@@ -14,11 +20,11 @@ fn include_and_exclude() {
 proptest! {
     #[test]
     fn include_exclude_ordering(file in "[a-z]{1,8}\\.tmp") {
-        let rules = parse(&format!("+ {}\n- *.tmp\n", file)).unwrap();
+        let rules = p(&format!("+ {}\n- *.tmp\n", file));
         let matcher = Matcher::new(rules);
         prop_assert!(matcher.is_included(&file).unwrap());
 
-        let rules_rev = parse(&format!("- *.tmp\n+ {}\n", file)).unwrap();
+        let rules_rev = p(&format!("- *.tmp\n+ {}\n", file));
         let matcher_rev = Matcher::new(rules_rev);
         prop_assert!(!matcher_rev.is_included(&file).unwrap());
     }

--- a/crates/filters/tests/malformed.rs
+++ b/crates/filters/tests/malformed.rs
@@ -1,4 +1,5 @@
 use filters::{parse, Matcher};
+use std::collections::HashSet;
 use std::fs;
 use tempfile::tempdir;
 
@@ -7,7 +8,8 @@ fn malformed_filter_file_returns_error() {
     let tmp = tempdir().unwrap();
     let root = tmp.path();
     fs::write(root.join(".rsync-filter"), "+\n").unwrap();
-    let rules = parse(": /.rsync-filter\n- .rsync-filter\n").unwrap();
+    let mut v = HashSet::new();
+    let rules = parse(": /.rsync-filter\n- .rsync-filter\n", &mut v, 0).unwrap();
     let matcher = Matcher::new(rules).with_root(root);
     assert!(matcher.is_included("foo").is_err());
 }

--- a/crates/filters/tests/merge_order.rs
+++ b/crates/filters/tests/merge_order.rs
@@ -1,4 +1,5 @@
 use filters::{parse, Matcher};
+use std::collections::HashSet;
 use std::fs;
 use tempfile::tempdir;
 
@@ -21,7 +22,8 @@ fn rsync_filter_merge_order_and_wildcards() {
     fs::write(nested.join(".rsync-filter"), "- debug.log\n").unwrap();
 
     // Global rules mirror recorded rsync behaviour with -F.
-    let global = parse(": /.rsync-filter\n- .rsync-filter\n+ *.log\n- *\n").unwrap();
+    let mut v = HashSet::new();
+    let global = parse(": /.rsync-filter\n- .rsync-filter\n+ *.log\n- *\n", &mut v, 0).unwrap();
     let matcher = Matcher::new(global).with_root(root);
 
     // Root rule overrides global include.
@@ -38,7 +40,8 @@ fn rsync_filter_merge_order_and_wildcards() {
 
 #[test]
 fn recorded_selection_parity() {
-    let rules = parse("+ *.txt\n- *\n").unwrap();
+    let mut v = HashSet::new();
+    let rules = parse("+ *.txt\n- *\n", &mut v, 0).unwrap();
     let matcher = Matcher::new(rules);
 
     assert!(matcher.is_included("a.txt").unwrap());

--- a/crates/filters/tests/recursive_filters.rs
+++ b/crates/filters/tests/recursive_filters.rs
@@ -1,0 +1,33 @@
+use filters::{parse, Matcher};
+use std::collections::HashSet;
+use std::fs;
+use tempfile::tempdir;
+
+#[test]
+fn self_referential_filter_is_error() {
+    let tmp = tempdir().unwrap();
+    let root = tmp.path();
+    fs::write(root.join(".rsync-filter"), ". .rsync-filter\n").unwrap();
+
+    let mut v = HashSet::new();
+    let rules = parse(": /.rsync-filter\n- .rsync-filter\n", &mut v, 0).unwrap();
+    let matcher = Matcher::new(rules).with_root(root);
+
+    assert!(matcher.is_included("file").is_err());
+}
+
+#[test]
+fn mutually_recursive_filters_error() {
+    let tmp = tempdir().unwrap();
+    let root = tmp.path();
+    let sub = root.join("sub");
+    fs::create_dir_all(&sub).unwrap();
+    fs::write(root.join(".rsync-filter"), ". sub/.rsync-filter\n").unwrap();
+    fs::write(sub.join(".rsync-filter"), ". ../.rsync-filter\n").unwrap();
+
+    let mut v = HashSet::new();
+    let rules = parse(": /.rsync-filter\n- .rsync-filter\n", &mut v, 0).unwrap();
+    let matcher = Matcher::new(rules).with_root(root);
+
+    assert!(matcher.is_included("sub/file").is_err());
+}

--- a/crates/filters/tests/rsync_parity.rs
+++ b/crates/filters/tests/rsync_parity.rs
@@ -1,4 +1,5 @@
 use filters::{parse, Matcher};
+use std::collections::HashSet;
 use std::fs;
 use std::process::Command;
 use tempfile::tempdir;
@@ -15,7 +16,8 @@ fn parity_with_stock_rsync() {
     fs::write(root.join("sub/keep.tmp"), "").unwrap();
     fs::write(root.join("sub/other.tmp"), "").unwrap();
 
-    let rules = parse(": /.rsync-filter\n- .rsync-filter\n").unwrap();
+    let mut v = HashSet::new();
+    let rules = parse(": /.rsync-filter\n- .rsync-filter\n", &mut v, 0).unwrap();
     let matcher = Matcher::new(rules).with_root(&root);
 
     let dest = tmp.path().join("dest");

--- a/crates/fuzz/fuzz_targets/filter_parser.rs
+++ b/crates/fuzz/fuzz_targets/filter_parser.rs
@@ -2,9 +2,11 @@
 use filters::parse;
 use fuzz::helpers;
 use libfuzzer_sys::fuzz_target;
+use std::collections::HashSet;
 
 fuzz_target!(|data: &[u8]| {
     if let Some(s) = helpers::as_str(data) {
-        let _ = parse(s);
+        let mut v = HashSet::new();
+        let _ = parse(s, &mut v, 0);
     }
 });

--- a/crates/fuzz/fuzz_targets/filters.rs
+++ b/crates/fuzz/fuzz_targets/filters.rs
@@ -2,10 +2,12 @@
 use filters::{parse, Matcher};
 use fuzz::helpers;
 use libfuzzer_sys::fuzz_target;
+use std::collections::HashSet;
 
 fuzz_target!(|data: &[u8]| {
     if let Some(s) = helpers::as_str(data) {
-        if let Ok(rules) = parse(s) {
+        let mut v = HashSet::new();
+        if let Ok(rules) = parse(s, &mut v, 0) {
             let matcher = Matcher::new(rules);
             let _ = matcher.is_included("test");
         }

--- a/crates/fuzz/fuzz_targets/filters_merge_fuzz.rs
+++ b/crates/fuzz/fuzz_targets/filters_merge_fuzz.rs
@@ -1,5 +1,6 @@
 #![no_main]
 use filters::{parse, Matcher};
+use std::collections::HashSet;
 use fuzz::helpers;
 use libfuzzer_sys::fuzz_target;
 
@@ -8,11 +9,12 @@ fuzz_target!(|data: &[u8]| {
         let parts: Vec<&str> = s.splitn(2, '\n').collect();
         let first = parts.get(0).copied().unwrap_or("");
         let second = parts.get(1).copied().unwrap_or("");
-        if let (Ok(r1), Ok(r2)) = (parse(first), parse(second)) {
+        let (mut v1, mut v2, mut v3) = (HashSet::new(), HashSet::new(), HashSet::new());
+        if let (Ok(r1), Ok(r2)) = (parse(first, &mut v1, 0), parse(second, &mut v2, 0)) {
             let mut merged = Matcher::new(r1.clone());
             merged.merge(r2.clone());
             let combined = format!("{}\n{}", first, second);
-            if let Ok(all) = parse(&combined) {
+            if let Ok(all) = parse(&combined, &mut v3, 0) {
                 let m2 = Matcher::new(all);
                 for path in ["a", "a.txt", "dir/file", "dir/sub/file.txt"] {
                     let _ = assert_eq!(merged.is_included(path), m2.is_included(path));

--- a/crates/fuzz/fuzz_targets/filters_parse_fuzz.rs
+++ b/crates/fuzz/fuzz_targets/filters_parse_fuzz.rs
@@ -1,9 +1,12 @@
 #![no_main]
 use fuzz::helpers;
 use libfuzzer_sys::fuzz_target;
+use std::collections::HashSet;
+use filters::parse;
 
 fuzz_target!(|data: &[u8]| {
     if let Some(s) = helpers::as_str(data) {
-        let _ = filters::parse(s);
+        let mut v = HashSet::new();
+        let _ = parse(s, &mut v, 0);
     }
 });


### PR DESCRIPTION
## Summary
- Track visited files and recursion depth in filter rule parsing
- Return a `ParseError` when a filter file is re-parsed or depth exceeds a limit
- Test self-referential and mutually recursive `.rsync-filter` files

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68b1a5e65ddc8323aa6a4d18f3d999a1