### PR TITLE
Use ATTR_CMN_CRTIME for creation time

### DIFF
--- a/crates/meta/src/lib.rs
+++ b/crates/meta/src/lib.rs
@@ -171,14 +171,14 @@ fn acl_to_io(err: posix_acl::ACLError) -> io::Error {
 
 #[cfg(any(target_os = "macos", target_os = "ios"))]
 fn set_file_crtime(path: &Path, crtime: FileTime) -> io::Result<()> {
-    use libc::{attrlist, setattrlist, timespec, ATTR_BIT_MAP_COUNT, ATTR_CMN_CRTIMESPEC};
+    use libc::{attrlist, setattrlist, timespec, ATTR_BIT_MAP_COUNT, ATTR_CMN_CRTIME};
     use std::ffi::CString;
     use std::mem;
 
     let mut attr = attrlist {
         bitmapcount: ATTR_BIT_MAP_COUNT as u16,
         reserved: 0,
-        commonattr: ATTR_CMN_CRTIMESPEC as u32,
+        commonattr: ATTR_CMN_CRTIME as u32,
         volattr: 0,
         dirattr: 0,
         fileattr: 0,


### PR DESCRIPTION
## Summary
- replace deprecated `ATTR_CMN_CRTIMESPEC` with `ATTR_CMN_CRTIME`
- initialize attrlist `commonattr` with `ATTR_CMN_CRTIME`

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68b1ac6e16888323a3e7d840f80ee259