### PR TITLE
Add OsStrExt import for macOS/iOS

### DIFF
--- a/crates/meta/src/lib.rs
+++ b/crates/meta/src/lib.rs
@@ -7,6 +7,9 @@ use filetime::{self, FileTime};
 use nix::sys::stat::{self, FchmodatFlags, Mode};
 use nix::unistd::{self, Gid, Uid};
 
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+use std::os::unix::ffi::OsStrExt;
+
 #[cfg(feature = "xattr")]
 use std::ffi::OsString;
 


### PR DESCRIPTION
## Summary
- Import `OsStrExt` on macOS/iOS to support `path.as_os_str().as_bytes()`

## Testing
- `cargo fmt --all -- --check`
- `cargo test -p meta`
- `cargo check -p meta --target x86_64-apple-darwin` *(fails: expected `*mut c_void`, found `&mut attrlist`)*

------
https://chatgpt.com/codex/tasks/task_e_68b1add6037483238f41d1aa2453cb42