### PR TITLE
Consolidate rsync-rs binary and update build docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: test-golden
 
 test-golden:
-	cargo build --quiet --bin rsync-rs
+	cargo build --quiet -p rsync-rs-bin --bin rsync-rs
 	@set -e; \
 	for script in tests/golden/cli_parity/*.sh; do \
 		echo "Running $$script"; \

--- a/README.md
+++ b/README.md
@@ -76,6 +76,16 @@ The project is organized as a set of focused crates:
 - `cli` – exposes a user-facing command line built on top of the engine and transport layers.
 - `fuzz` – houses fuzz targets that stress protocol and parser logic for robustness.
 
+## Building
+
+The CLI entry point resides in the `bin/rsync-rs` crate. Build or run it with Cargo:
+
+```
+cargo build -p rsync-rs-bin --bin rsync-rs
+# or
+cargo run -p rsync-rs-bin -- <args>
+```
+
 ## Milestone Roadmap
 1. **M1—Bootstrap** – repository builds; `walk` and `checksums` crates generate file signatures.
 2. **M2—Delta Engine** – `engine` drives local delta transfers with metadata preservation.

--- a/crates/compress/src/lib.rs
+++ b/crates/compress/src/lib.rs
@@ -118,6 +118,7 @@ impl Decompressor for Zlib {
 }
 
 /// Zstandard codec adapter.
+#[derive(Default)]
 pub struct Zstd {
     level: i32,
 }
@@ -126,12 +127,6 @@ impl Zstd {
     /// Create a new zstd codec with the given compression level.
     pub fn new(level: i32) -> Self {
         Self { level }
-    }
-}
-
-impl Default for Zstd {
-    fn default() -> Self {
-        Self { level: 0 }
     }
 }
 

--- a/crates/meta/src/lib.rs
+++ b/crates/meta/src/lib.rs
@@ -1,4 +1,3 @@
-use std::convert::TryInto;
 use std::fs;
 use std::io;
 use std::path::Path;
@@ -118,10 +117,7 @@ impl Metadata {
         )
         .map_err(nix_to_io)?;
 
-        let mode_t: libc::mode_t = self
-            .mode
-            .try_into()
-            .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "mode does not fit into mode_t"))?;
+        let mode_t: libc::mode_t = self.mode as libc::mode_t;
         let mode = Mode::from_bits_truncate(mode_t);
         stat::fchmodat(None, path, mode, FchmodatFlags::NoFollowSymlink).map_err(nix_to_io)?;
 
@@ -168,7 +164,7 @@ fn acl_to_io(err: posix_acl::ACLError) -> io::Error {
             io::Error::new(e.kind(), e.to_string())
         }
     } else {
-        io::Error::new(io::ErrorKind::Other, err)
+        io::Error::other(err)
     }
 }
 

--- a/crates/walk/src/lib.rs
+++ b/crates/walk/src/lib.rs
@@ -109,7 +109,7 @@ impl Iterator for Walk {
                     #[cfg(unix)]
                     let meta = match std::fs::symlink_metadata(entry.path()) {
                         Ok(m) => m,
-                        Err(e) => return Some(Err(e.into())),
+                        Err(e) => return Some(Err(e)),
                     };
                     #[cfg(unix)]
                     let (uid, gid, dev) = (meta.uid(), meta.gid(), meta.dev());
@@ -144,7 +144,7 @@ impl Iterator for Walk {
                     let msg = err.to_string();
                     let io_err = match err.into_io_error() {
                         Some(inner) => inner,
-                        None => io::Error::new(io::ErrorKind::Other, msg),
+                        None => io::Error::other(msg),
                     };
                     return Some(Err(io_err));
                 }

--- a/docs/project_overview.md
+++ b/docs/project_overview.md
@@ -14,7 +14,7 @@
 - **fuzz**: fuzz targets validating protocol and filter robustness.
 
 ## Binaries
-- **rsync-rs**: main CLI entry point.
+- **rsync-rs** (`bin/rsync-rs` crate): main CLI entry point.
 - **protocol_frame_decode_fuzz**: fuzz target exercising protocol frame decoding.
 - **filters_parse_fuzz**: fuzz target exercising filter rule parsing.
 

--- a/scripts/interop.sh
+++ b/scripts/interop.sh
@@ -12,7 +12,7 @@ FLAGS=(--recursive --times --perms)
 mkdir -p "$WIRE_DIR" "$FILELIST_DIR"
 
 # Build rsync-rs binary
-cargo build --quiet --bin rsync-rs
+cargo build --quiet -p rsync-rs-bin --bin rsync-rs
 
 # Ensure sshd exists
 if ! command -v sshd >/dev/null 2>&1; then

--- a/src/bin/rsync-rs.rs
+++ b/src/bin/rsync-rs.rs
@@ -1,3 +1,1 @@
-fn main() -> engine::Result<()> {
-    cli::run()
-}
+include!("../../bin/rsync-rs/src/main.rs");

--- a/tests/filter_rule_precedence.sh
+++ b/tests/filter_rule_precedence.sh
@@ -5,7 +5,7 @@ ROOT="$(git rev-parse --show-toplevel)"
 RSYNC_RS="$ROOT/target/debug/rsync-rs"
 
 # Ensure binary is built
-cargo build --quiet --bin rsync-rs
+cargo build --quiet -p rsync-rs-bin --bin rsync-rs
 
 TMP=$(mktemp -d)
 trap 'rm -rf "$TMP"' EXIT

--- a/tests/partial_transfer_resume.sh
+++ b/tests/partial_transfer_resume.sh
@@ -5,7 +5,7 @@ ROOT="$(git rev-parse --show-toplevel)"
 RSYNC_RS="$ROOT/target/debug/rsync-rs"
 
 # Ensure binary is built
-cargo build --quiet --bin rsync-rs
+cargo build --quiet -p rsync-rs-bin --bin rsync-rs
 
 TMP=$(mktemp -d)
 trap 'rm -rf "$TMP"' EXIT


### PR DESCRIPTION
## Summary
- redirect root `rsync-rs` binary to shared implementation
- build scripts and docs point to `bin/rsync-rs` crate
- clean up lint warnings in meta, walk and compress crates

## Testing
- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: could not compile `engine` due to existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b1b6d29da08323bf283dd618058437