### PR TITLE
docs: clarify --modern parity and enhancements

### DIFF
--- a/docs/differences.md
+++ b/docs/differences.md
@@ -1,10 +1,15 @@
 # Differences from rsync
 
-`rsync-rs` strives to mirror the traditional `rsync` command line. The table
-below highlights how common flags map to current support and how the
-`--modern` convenience flag influences behavior. For a complete listing see
+`rsync-rs` aims for parity with stock `rsync` 3.2.x. When run without the
+`--modern` flag, it intends zero behavioral differences from the traditional
+utility and mirrors the classic command line.
+
+The `--modern` convenience flag enables additional enhancements beyond
+classic `rsync` behavior. For a complete listing see
 [cli/flags.md](cli/flags.md). For detailed parity status see
 [feature_matrix.md](feature_matrix.md).
+
+## `--modern` enhancements
 
 | rsync flag | rsync-rs status | Tests | `--modern` notes |
 |------------|-----------------|-------|------------------|


### PR DESCRIPTION
## Summary
- clarify that rsync-rs matches rsync 3.2.x behavior unless `--modern` is used
- group option table under a new `--modern` enhancements section

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68b1db38a6e48323ac2ded80dafd1924