### PR TITLE
Gate daemon sync helpers on xattr/acl features

### DIFF
--- a/tests/daemon_sync_attrs.rs
+++ b/tests/daemon_sync_attrs.rs
@@ -1,11 +1,18 @@
-use assert_cmd::cargo::CommandCargoExt;
-use assert_cmd::Command;
+#[cfg(all(unix, any(feature = "xattr", feature = "acl")))]
+use assert_cmd::{cargo::CommandCargoExt, Command};
+#[cfg(all(unix, any(feature = "xattr", feature = "acl")))]
 use serial_test::serial;
+#[cfg(all(unix, any(feature = "xattr", feature = "acl")))]
 use std::fs;
+#[cfg(all(unix, any(feature = "xattr", feature = "acl")))]
 use std::net::{TcpListener, TcpStream};
+#[cfg(all(unix, any(feature = "xattr", feature = "acl")))]
 use std::process::{Child, Command as StdCommand};
+#[cfg(all(unix, any(feature = "xattr", feature = "acl")))]
 use std::thread::sleep;
+#[cfg(all(unix, any(feature = "xattr", feature = "acl")))]
 use std::time::Duration;
+#[cfg(all(unix, any(feature = "xattr", feature = "acl")))]
 use tempfile::tempdir;
 
 #[cfg(all(unix, feature = "acl"))]
@@ -13,6 +20,7 @@ use posix_acl::{PosixACL, Qualifier, ACL_READ};
 #[cfg(all(unix, feature = "xattr"))]
 use xattr;
 
+#[cfg(all(unix, any(feature = "xattr", feature = "acl")))]
 fn spawn_daemon(root: &std::path::Path) -> (Child, u16) {
     let port = TcpListener::bind("127.0.0.1:0")
         .unwrap()
@@ -33,6 +41,7 @@ fn spawn_daemon(root: &std::path::Path) -> (Child, u16) {
     (child, port)
 }
 
+#[cfg(all(unix, any(feature = "xattr", feature = "acl")))]
 fn wait_for_daemon(port: u16) {
     for _ in 0..20 {
         if TcpStream::connect(("127.0.0.1", port)).is_ok() {


### PR DESCRIPTION
## Summary
- conditionally compile daemon sync helper imports and functions depending on xattr or acl features

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68b1e299ef98832395d064b5a1154313