### PR TITLE
Remove unnecessary mut from resume variable

### DIFF
--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -657,7 +657,7 @@ impl Receiver {
             fs::create_dir_all(parent)?;
         }
 
-        let (mut out, mut resume) = if self.opts.inplace {
+        let (mut out, resume) = if self.opts.inplace {
             let f = OpenOptions::new()
                 .read(true)
                 .write(true)


### PR DESCRIPTION
## Summary
- clean up receiver apply by removing unnecessary mut from resume

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68b1e29348cc8323a8b2b605ef54279a