### PR TITLE
Handle complex --rsh commands and env handshake

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -126,6 +126,21 @@ copied:
 
 Flags such as `-P` and `--numeric-ids` mirror their `rsync` behavior. See the [CLI flag reference](cli/flags.md) for implementation details and notes.
 
+## Remote shell
+
+The `--rsh` (`-e`) flag accepts an arbitrary shell command. The command string
+is parsed using shell-style quoting, allowing multiple arguments and embedded
+quotes much like GNU `rsync`. Leading `VAR=value` tokens set environment
+variables for the spawned command. For example:
+
+```
+rsync-rs -e 'RUST_LOG=debug ssh -p 2222 -o "StrictHostKeyChecking=no"' src dst
+```
+
+During the connection handshake `rsync-rs` also forwards any environment
+variables from its own process whose names begin with `RSYNC_`, mirroring
+`rsync`'s environment propagation behavior.
+
 ## Configuration precedence
 
 1. Command-line flags

--- a/docs/gaps.md
+++ b/docs/gaps.md
@@ -5,7 +5,6 @@ This document tracks outstanding gaps in `rsync-rs` compared to the reference `r
 ## Missing rsync behaviors
 
 ### Protocol gaps
-- Remote shell (`--rsh`) negotiation is incomplete, lacking full `rsh` command parsing and environment handshakes.
 - Partial transfer resumption does not fully match `rsync` semantics; interrupted copies cannot reuse partially transferred data.
 - Compression support includes zlib and zstd, with optional LZ4 available when the `lz4` feature is enabled.
 


### PR DESCRIPTION
## Summary
- Parse `--rsh` strings with shell-like quoting, multiple args and leading env assignments
- Propagate `RSYNC_*` vars via `SshStdioTransport` environment handshake with improved diagnostics
- Document remote shell behavior and add unit tests for multi-arg and env handling

## Testing
- `cargo test --tests rsh -- --skip modern_negotiates_blake3_and_zstd`

------
https://chatgpt.com/codex/tasks/task_e_68b1e0cf30a483238c7c6d2264bfb0a4