### PR TITLE
Fix anchored dir-merge path handling

### DIFF
--- a/crates/filters/src/lib.rs
+++ b/crates/filters/src/lib.rs
@@ -125,15 +125,22 @@ impl Matcher {
 
         let mut combined = Vec::new();
         for pd in &self.per_dir {
-            let path = dir.join(&pd.file);
+            let path = if pd.anchored {
+                if let Some(root) = &self.root {
+                    root.join(&pd.file)
+                } else {
+                    dir.join(&pd.file)
+                }
+            } else {
+                dir.join(&pd.file)
+            };
             let mut cache = self.cached.borrow_mut();
             if let Some(r) = cache.get(&path) {
                 combined.extend(r.clone());
                 continue;
             }
             let rel = if !pd.anchored {
-                self
-                    .root
+                self.root
                     .as_ref()
                     .and_then(|r| dir.strip_prefix(r).ok())
                     .filter(|p| !p.as_os_str().is_empty())

--- a/crates/filters/tests/anchored_dir_merge.rs
+++ b/crates/filters/tests/anchored_dir_merge.rs
@@ -1,0 +1,26 @@
+use filters::{parse, Matcher};
+use std::collections::HashSet;
+use std::fs;
+use tempfile::tempdir;
+
+#[test]
+fn anchored_dir_merge_uses_root_file() {
+    let tmp = tempdir().unwrap();
+    let root = tmp.path();
+
+    // Root filter excludes "secret".
+    fs::write(root.join(".rsync-filter"), "- secret\n").unwrap();
+    // Subdirectory filter attempts to include "secret" but should be ignored.
+    let sub = root.join("sub");
+    fs::create_dir_all(&sub).unwrap();
+    fs::write(sub.join(".rsync-filter"), "+ secret\n").unwrap();
+
+    let mut v = HashSet::new();
+    let rules = parse("dir-merge /.rsync-filter\n", &mut v, 0).unwrap();
+    let matcher = Matcher::new(rules).with_root(root);
+
+    // The anchored dir-merge directive should always load the filter from the
+    // transfer root, so the subdirectory's attempt to override it is ignored.
+    assert!(!matcher.is_included("secret").unwrap());
+    assert!(!matcher.is_included("sub/secret").unwrap());
+}


### PR DESCRIPTION
## Summary
- ensure anchored per-directory merge rules resolve paths from the transfer root
- test that anchored dir-merge rules ignore subdirectory filters

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b1e805ab088323952d2191ff0465c8