### PR TITLE
Scope per-dir patterns to directory

### DIFF
--- a/crates/filters/src/lib.rs
+++ b/crates/filters/src/lib.rs
@@ -132,8 +132,7 @@ impl Matcher {
                 continue;
             }
             let rel = if !pd.anchored {
-                self
-                    .root
+                self.root
                     .as_ref()
                     .and_then(|r| dir.strip_prefix(r).ok())
                     .filter(|p| !p.as_os_str().is_empty())
@@ -165,10 +164,8 @@ impl Matcher {
                             };
                             let new_pat = if pat.starts_with('/') {
                                 pat.to_string()
-                            } else if pat.contains('/') {
-                                format!("{}/{}", rel_str, pat)
                             } else {
-                                format!("{}/**/{}", rel_str, pat)
+                                format!("{}/{}", rel_str, pat)
                             };
                             buf.push(kind);
                             buf.push(' ');

--- a/tests/filter_corpus.rs
+++ b/tests/filter_corpus.rs
@@ -23,6 +23,8 @@ fn setup_perdir(src: &Path) {
     fs::write(src.join("sub/keep.tmp"), "keep").unwrap();
     fs::write(src.join("sub/other.tmp"), "other").unwrap();
     fs::write(src.join("sub/other.txt"), "other").unwrap();
+    fs::create_dir_all(src.join("sub/nested")).unwrap();
+    fs::write(src.join("sub/nested/keep.tmp"), "nested").unwrap();
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Prefix unanchored per-directory patterns with their directory path without `/**/`
- Extend filter corpus test to cover nested files in per-directory filters

## Testing
- `cargo test` *(fails: test modern_negotiates_blake3_and_zstd has been running for over 60 seconds)*

------
https://chatgpt.com/codex/tasks/task_e_68b1e802fc64832387fb6f6cafe843a8