### PR TITLE
Add backup directory support

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -75,6 +75,12 @@ struct ClientOpts {
     /// also delete excluded files from destination
     #[arg(long = "delete-excluded", help_heading = "Delete")]
     delete_excluded: bool,
+    /// make backups (see --backup-dir)
+    #[arg(short = 'b', long, help_heading = "Backup")]
+    backup: bool,
+    /// make backups into hierarchy based in DIR
+    #[arg(long = "backup-dir", value_name = "DIR", help_heading = "Backup")]
+    backup_dir: Option<PathBuf>,
     /// use full checksums to determine file changes
     #[arg(short = 'c', long, help_heading = "Attributes")]
     checksum: bool,
@@ -710,6 +716,8 @@ fn run_client(opts: ClientOpts, matches: &ArgMatches) -> Result<()> {
         link_dest: opts.link_dest.clone(),
         copy_dest: opts.copy_dest.clone(),
         compare_dest: opts.compare_dest.clone(),
+        backup: opts.backup || opts.backup_dir.is_some(),
+        backup_dir: opts.backup_dir.clone(),
     };
     let stats = if opts.local {
         match (src, dst) {
@@ -1128,8 +1136,7 @@ fn build_matcher(opts: &ClientOpts, matches: &ArgMatches) -> Result<Matcher> {
             if count >= 1 {
                 add_rules(
                     idx,
-                    parse_filters("-F")
-                        .map_err(|e| EngineError::Other(format!("{:?}", e)))?,
+                    parse_filters("-F").map_err(|e| EngineError::Other(format!("{:?}", e)))?,
                 );
             }
             if count >= 2 {

--- a/crates/engine/tests/backup.rs
+++ b/crates/engine/tests/backup.rs
@@ -1,0 +1,39 @@
+use std::fs;
+
+use compress::available_codecs;
+use engine::{sync, DeleteMode, SyncOptions};
+use filters::Matcher;
+use tempfile::tempdir;
+
+#[test]
+fn backups_replaced_and_deleted_files() {
+    let tmp = tempdir().unwrap();
+    let src = tmp.path().join("src");
+    let dst = tmp.path().join("dst");
+    let backup = tmp.path().join("backup");
+    fs::create_dir_all(&src).unwrap();
+    fs::create_dir_all(&dst).unwrap();
+    fs::write(dst.join("file.txt"), b"old").unwrap();
+    std::thread::sleep(std::time::Duration::from_secs(1));
+    fs::write(src.join("file.txt"), b"new").unwrap();
+    fs::write(dst.join("old.txt"), b"obsolete").unwrap();
+
+    sync(
+        &src,
+        &dst,
+        &Matcher::default(),
+        available_codecs(),
+        &SyncOptions {
+            delete: Some(DeleteMode::During),
+            backup: true,
+            backup_dir: Some(backup.clone()),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    assert_eq!(fs::read(dst.join("file.txt")).unwrap(), b"new");
+    assert_eq!(fs::read(backup.join("file.txt")).unwrap(), b"old");
+    assert_eq!(fs::read(backup.join("old.txt")).unwrap(), b"obsolete");
+    assert!(!dst.join("old.txt").exists());
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -89,6 +89,8 @@ copied:
 | | `--delete-delay` | off | find deletions during, delete after |
 | | `--delete-after` | off | receiver deletes after transfer, not during |
 | | `--delete-excluded` | off | also delete excluded files from dest dirs |
+| `-b` | `--backup` | off | make backups of replaced or removed files |
+| | `--backup-dir=DIR` | none | store backups under DIR |
 | | `--partial` | off | keep partially transferred files |
 | | `--partial-dir=DIR` | none | put a partially transferred file into DIR |
 | | `--numeric-ids` | off | don't map uid/gid values by user/group name |

--- a/docs/cli/flags.md
+++ b/docs/cli/flags.md
@@ -147,8 +147,8 @@
 |  | --append | append data onto shorter files | no |  | no |
 |  | --append-verify | --append w/old data in file checksum | no |  | no |
 | -a | --archive | archive mode is -rlptgoD (no -A,-X,-U,-N,-H) | yes |  | no |
-| -b | --backup | make backups (see --suffix & --backup-dir) | no |  | no |
-|  | --backup-dir=DIR | make backups into hierarchy based in DIR | no |  | no |
+| -b | --backup | make backups (see --suffix & --backup-dir) | yes |  | no |
+|  | --backup-dir=DIR | make backups into hierarchy based in DIR | yes |  | no |
 | -B | --block-size=SIZE | force a fixed checksum block-size | no |  | no |
 | -c | --checksum | skip based on checksum, not mod-time & size | no | Parsed but not implemented | no |
 |  | --checksum-choice=STR | choose the checksum algorithm (aka --cc) | no |  | no |

--- a/docs/feature_matrix.md
+++ b/docs/feature_matrix.md
@@ -12,8 +12,8 @@ See [differences.md](differences.md) for a summary of notable behavioral differe
 | `--append-verify` | — | ✅ | ❌ | [tests/resume.rs](../tests/resume.rs) |  | ≤3.2 |
 | `--archive` | `-a` | ✅ | ❌ | [tests/interop/run_matrix.sh](../tests/interop/run_matrix.sh) |  | ≤3.2 |
 | `--atimes` | `-U` | ✅ | ❌ | [crates/engine/tests/attrs.rs](../crates/engine/tests/attrs.rs) |  | ≤3.2 |
-| `--backup` | `-b` | ❌ | — | — |  | ≤3.2 |
-| `--backup-dir` | — | ❌ | — | — |  | ≤3.2 |
+| `--backup` | `-b` | ✅ | ✅ | [crates/engine/tests/backup.rs](../crates/engine/tests/backup.rs) | uses `~` suffix without `--backup-dir` | ≤3.2 |
+| `--backup-dir` | — | ✅ | ✅ | [crates/engine/tests/backup.rs](../crates/engine/tests/backup.rs) | implies `--backup` | ≤3.2 |
 | `--block-size` | `-B` | ❌ | — | — |  | ≤3.2 |
 | `--blocking-io` | — | ❌ | — | — |  | ≤3.2 |
 | `--bwlimit` | — | ✅ | ❌ | [crates/transport/tests/bwlimit.rs](../crates/transport/tests/bwlimit.rs) |  | ≤3.2 |

--- a/tools/flag_matrix.json
+++ b/tools/flag_matrix.json
@@ -36,12 +36,12 @@
   },
   {
     "flag": "--backup",
-    "status": "Error",
+    "status": "Supported",
     "notes": ""
   },
   {
     "flag": "--backup-dir",
-    "status": "Error",
+    "status": "Supported",
     "notes": ""
   },
   {

--- a/tools/flag_matrix.md
+++ b/tools/flag_matrix.md
@@ -7,8 +7,8 @@
 | --append-verify | Error |  |
 | --archive | Supported |  |
 | --atimes | Supported |  |
-| --backup | Error |  |
-| --backup-dir | Error |  |
+| --backup | Supported |  |
+| --backup-dir | Supported |  |
 | --block-size | Error |  |
 | --blocking-io | Error |  |
 | --bwlimit | Error |  |


### PR DESCRIPTION
## Summary
- add `--backup`/`--backup-dir` flags to CLI
- copy replaced or deleted files into backup locations
- document backup options and mark them supported

## Testing
- `cargo test -p engine backups_replaced_and_deleted_files -- --nocapture`
- `cargo test` *(fails: modern_negotiates_blake3_and_zstd runs >60s)*


------
https://chatgpt.com/codex/tasks/task_e_68b1f27dabd88323919e784b4a7d77e9