### PR TITLE
Handle symlink resolution flags

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -105,6 +105,15 @@ struct ClientOpts {
     /// copy symlinks as symlinks
     #[arg(long, help_heading = "Attributes")]
     links: bool,
+    /// transform symlink into referent file/dir
+    #[arg(short = 'L', long, help_heading = "Attributes")]
+    copy_links: bool,
+    /// only "unsafe" symlinks are transformed
+    #[arg(long, help_heading = "Attributes")]
+    copy_unsafe_links: bool,
+    /// ignore symlinks that point outside the tree
+    #[arg(long, help_heading = "Attributes")]
+    safe_links: bool,
     /// preserve hard links
     #[arg(long = "hard-links", help_heading = "Attributes")]
     hard_links: bool,
@@ -699,6 +708,9 @@ fn run_client(opts: ClientOpts, matches: &ArgMatches) -> Result<()> {
         owner: opts.owner || opts.archive,
         group: opts.group || opts.archive,
         links: opts.links || opts.archive,
+        copy_links: opts.copy_links,
+        copy_unsafe_links: opts.copy_unsafe_links,
+        safe_links: opts.safe_links,
         hard_links: opts.hard_links,
         devices: opts.devices || opts.archive,
         specials: opts.specials || opts.archive,


### PR DESCRIPTION
## Summary
- add `--copy-links`, `--copy-unsafe-links`, and `--safe-links` CLI flags
- implement symlink resolution logic in engine respecting new flags
- test unsafe and directory symlink handling

## Testing
- `cargo test --test symlink_resolution`
- ⚠️ `cargo test` *(exited early)*

------
https://chatgpt.com/codex/tasks/task_e_68b1ff6d0948832393e0465d66fde0a4