### PR TITLE
feat: support chmod flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,12 +83,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arbitrary"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
-
-[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -299,6 +293,7 @@ dependencies = [
  "compress",
  "engine",
  "filters",
+ "meta",
  "nix",
  "protocol",
  "shell-words",
@@ -600,17 +595,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fuzz"
-version = "0.1.0"
-dependencies = [
- "cli",
- "filters",
- "libfuzzer-sys",
- "protocol",
- "walk",
-]
-
-[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -748,16 +732,6 @@ name = "libc"
 version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
-
-[[package]]
-name = "libfuzzer-sys"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5037190e1f70cbeef565bd267599242926f724d3b8a9f510fd7e0b540cfa4404"
-dependencies = [
- "arbitrary",
- "cc",
-]
 
 [[package]]
 name = "libredox"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -12,6 +12,7 @@ transport = { path = "../transport" }
 nix = { version = "0.27", features = ["fs", "user"] }
 compress = { path = "../compress" }
 shell-words = "1.1"
+meta = { path = "../meta", default-features = false }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -787,6 +787,7 @@ impl Receiver {
                         false
                     }
                 },
+                chmod: self.opts.chmod.clone(),
             };
 
             if self.opts.perms
@@ -798,7 +799,8 @@ impl Receiver {
                 || meta_opts.xattrs
                 || meta_opts.acl
             {
-                let meta = meta::Metadata::from_path(src, meta_opts).map_err(EngineError::from)?;
+                let meta =
+                    meta::Metadata::from_path(src, meta_opts.clone()).map_err(EngineError::from)?;
                 meta.apply(dest, meta_opts).map_err(EngineError::from)?;
             }
         }
@@ -857,6 +859,7 @@ pub struct SyncOptions {
     pub compare_dest: Option<PathBuf>,
     pub backup: bool,
     pub backup_dir: Option<PathBuf>,
+    pub chmod: Option<Vec<meta::Chmod>>,
 }
 
 impl Default for SyncOptions {
@@ -901,6 +904,7 @@ impl Default for SyncOptions {
             compare_dest: None,
             backup: false,
             backup_dir: None,
+            chmod: None,
         }
     }
 }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -74,6 +74,7 @@ copied:
 | `-l` | `--links` | off | copy symlinks as symlinks |
 | | `--hard-links` | off | preserve hard links |
 | | `--perms` | off | preserve permissions |
+| | `--chmod=CHMOD` | none | affect file and/or directory permissions |
 | | `--acls` | off | preserve ACLs (implies --perms) |
 | | `--xattrs` | off | preserve extended attributes |
 | | `--owner` | off | preserve owner (super-user only) |
@@ -132,6 +133,21 @@ copied:
 | | `--motd=FILE` | none | path to message of the day file |
 
 Flags such as `-P` and `--numeric-ids` mirror their `rsync` behavior. See the [CLI flag reference](cli/flags.md) for implementation details and notes.
+
+### Permission tweaks with `--chmod`
+
+The `--chmod=CHMOD` option adjusts permission bits on transferred files. The
+syntax mirrors `chmod` and supports comma-separated rules. Prefix a rule with
+`D` or `F` to limit it to directories or files respectively.
+
+Examples:
+
+- `--chmod=Du+rwx` adds user read/write/execute for directories.
+- `--chmod=F644` forces regular files to mode `644`.
+- `--chmod=ug=rwX,o=rX` sets user and group read/write and conditional execute while
+  giving others read access.
+
+Multiple `--chmod` flags accumulate.
 
 ## Remote shell
 


### PR DESCRIPTION
## Summary
- parse `--chmod` rules in the CLI
- apply parsed permission changes during metadata apply
- document `--chmod` syntax and examples

## Testing
- `cargo clippy --all-targets --all-features`
- `cargo test` *(fails: test modern_negotiates_blake3_and_zstd hung for over 60s)*

------
https://chatgpt.com/codex/tasks/task_e_68b2053e7e408323914f9c084af90bba