### PR TITLE
test: add remote↔remote SSH and daemon cases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1103,6 +1103,7 @@ dependencies = [
  "shell-words",
  "tempfile",
  "transport",
+ "wait-timeout",
  "xattr",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ posix-acl = "1.2"
 transport = { path = "crates/transport" }
 filetime = "0.2"
 shell-words = "1.1"
+wait-timeout = "0.2"
 
 [[bin]]
 name = "flag_matrix"


### PR DESCRIPTION
## Summary
- add ignored remote↔remote tests covering `--rsh` and `rsync://` scenarios
- extend interop run matrix for remote↔remote SSH and daemon paths
- add wait-timeout dev dependency for graceful command timeouts

## Testing
- `cargo test --test remote_remote remote_remote_via_rsh_matches_rsync -q` *(ignored)*
- `cargo test --test remote_remote remote_remote_via_rsync_urls_match_rsync -q` *(ignored)*
- `bash -n tests/interop/run_matrix.sh`
- `timeout 10 bash tests/interop/run_matrix.sh` *(timeout)*

------
https://chatgpt.com/codex/tasks/task_e_68b20c4985f08323ba00c499cff9c3c7