### PR TITLE
Add timeout options and apply network timeouts

### DIFF
--- a/crates/protocol/src/server.rs
+++ b/crates/protocol/src/server.rs
@@ -21,14 +21,13 @@ pub struct Server<R: Read, W: Write> {
 }
 
 impl<R: Read, W: Write> Server<R, W> {
-    /// Create a new server state machine with default keepalive and timeout
-    /// durations of 30 seconds.
-    pub fn new(reader: R, writer: W) -> Self {
+    /// Create a new server state machine with the specified keepalive and timeout duration.
+    pub fn new(reader: R, writer: W, timeout: Duration) -> Self {
         Server {
             reader,
             writer,
-            mux: Mux::new(Duration::from_secs(30)),
-            demux: Demux::new(Duration::from_secs(30)),
+            mux: Mux::new(timeout),
+            demux: Demux::new(timeout),
             version: 0,
         }
     }

--- a/crates/protocol/tests/server.rs
+++ b/crates/protocol/tests/server.rs
@@ -1,6 +1,7 @@
 use compress::{available_codecs, encode_codecs};
 use protocol::{Server, CAP_CODECS, LATEST_VERSION};
 use std::io::Cursor;
+use std::time::Duration;
 
 #[test]
 fn server_negotiates_version() {
@@ -15,7 +16,7 @@ fn server_negotiates_version() {
         v
     });
     let mut output = Vec::new();
-    let mut srv = Server::new(&mut input, &mut output);
+    let mut srv = Server::new(&mut input, &mut output, Duration::from_secs(30));
     let peer_codecs = srv.handshake().unwrap();
     assert_eq!(srv.version, LATEST_VERSION);
     assert_eq!(peer_codecs, available_codecs());

--- a/crates/transport/tests/tcp.rs
+++ b/crates/transport/tests/tcp.rs
@@ -17,7 +17,7 @@ fn send_receive_over_tcp() {
         stream.write_all(&buf).unwrap();
     });
 
-    let mut transport = TcpTransport::connect(&addr.to_string()).expect("connect");
+    let mut transport = TcpTransport::connect(&addr.to_string(), None).expect("connect");
     transport.send(b"ping").expect("send");
     let mut buf = [0u8; 4];
     let n = transport.receive(&mut buf).expect("receive");

--- a/docs/cli/flags.md
+++ b/docs/cli/flags.md
@@ -154,7 +154,7 @@
 |  | --checksum-choice=STR | choose the checksum algorithm (aka --cc) | no |  | no |
 |  | --checksum-seed=NUM | set block/file checksum seed (advanced) | no |  | no |
 |  | --compare-dest=DIR | also compare destination files relative to DIR | yes |  | no |
-|  | --contimeout=SECONDS | set daemon connection timeout in seconds | no |  | no |
+|  | --contimeout=SECONDS | set daemon connection timeout in seconds | yes |  | no |
 |  | --copy-dest=DIR | ... and include copies of unchanged files | yes |  | no |
 | -k | --copy-dirlinks | transform symlink to dir into referent dir | no |  | no |
 | -L | --copy-links | transform symlink into referent file/dir | no |  | no |
@@ -192,6 +192,6 @@
 | -S | --sparse | turn sequences of nulls into sparse blocks (requires filesystem support) | yes |  | no |
 |  | --suffix=SUFFIX | backup suffix (default ~ w/o --backup-dir) | no |  | no |
 | -T | --temp-dir=DIR | create temporary files in directory DIR | no |  | no |
-|  | --timeout=SECONDS | set I/O timeout in seconds | no |  | no |
+|  | --timeout=SECONDS | set I/O timeout in seconds | yes |  | no |
 | -u | --update | skip files that are newer on the receiver | no |  | no |
 | -W | --whole-file | copy files whole (w/o delta-xfer algorithm) | no |  | no |

--- a/docs/feature_matrix.md
+++ b/docs/feature_matrix.md
@@ -29,7 +29,7 @@ See [differences.md](differences.md) for a summary of notable behavioral differe
 | `--compress-level` | — | ✅ | ✅ | [tests/golden/cli_parity/compress-level.sh](../tests/golden/cli_parity/compress-level.sh) | applies to zlib or zstd | ≤3.2 |
 | `--zc` | — | ✅ | ✅ | [tests/golden/cli_parity/compress-choice.sh](../tests/golden/cli_parity/compress-choice.sh) | alias for `--compress-choice` | ≤3.2 |
 | `--zl` | — | ✅ | ✅ | [tests/golden/cli_parity/compress-level.sh](../tests/golden/cli_parity/compress-level.sh) | alias for `--compress-level` | ≤3.2 |
-| `--contimeout` | — | ❌ | — | — |  | ≤3.2 |
+| `--contimeout` | — | ✅ | ❌ | [tests/timeout.rs](../tests/timeout.rs) |  | ≤3.2 |
 | `--copy-as` | — | ❌ | — | — |  | ≤3.2 |
 | `--copy-dest` | — | ✅ | ✅ | [tests/link_copy_compare_dest.rs](../tests/link_copy_compare_dest.rs) |  | ≤3.2 |
 | `--copy-devices` | — | ❌ | — | — |  | ≤3.2 |
@@ -144,7 +144,7 @@ See [differences.md](differences.md) for a summary of notable behavioral differe
 | `--suffix` | — | ❌ | — | — |  | ≤3.2 |
 | `--super` | — | ❌ | — | — |  | ≤3.2 |
 | `--temp-dir` | `-T` | ❌ | — | — |  | ≤3.2 |
-| `--timeout` | — | ❌ | — | — |  | ≤3.2 |
+| `--timeout` | — | ✅ | ❌ | [tests/timeout.rs](../tests/timeout.rs) |  | ≤3.2 |
 | `--times` | `-t` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  | ≤3.2 |
 | `--trust-sender` | — | ❌ | — | — |  | ≤3.2 |
 | `--update` | `-u` | ❌ | — | — |  | ≤3.2 |

--- a/tests/daemon.rs
+++ b/tests/daemon.rs
@@ -141,7 +141,7 @@ fn daemon_rejects_invalid_token() {
         .spawn()
         .unwrap();
     wait_for_daemon(port);
-    let mut t = TcpTransport::connect(&format!("127.0.0.1:{port}")).unwrap();
+    let mut t = TcpTransport::connect(&format!("127.0.0.1:{port}"), None).unwrap();
     t.send(&LATEST_VERSION.to_be_bytes()).unwrap();
     let mut buf = [0u8; 4];
     t.receive(&mut buf).unwrap();
@@ -184,7 +184,7 @@ fn daemon_rejects_unauthorized_module() {
         .spawn()
         .unwrap();
     wait_for_daemon(port);
-    let mut t = TcpTransport::connect(&format!("127.0.0.1:{port}")).unwrap();
+    let mut t = TcpTransport::connect(&format!("127.0.0.1:{port}"), None).unwrap();
     t.send(&LATEST_VERSION.to_be_bytes()).unwrap();
     let mut buf = [0u8; 4];
     t.receive(&mut buf).unwrap();
@@ -228,7 +228,7 @@ fn daemon_accepts_authorized_client() {
         .spawn()
         .unwrap();
     wait_for_daemon(port);
-    let mut t = TcpTransport::connect(&format!("127.0.0.1:{port}")).unwrap();
+    let mut t = TcpTransport::connect(&format!("127.0.0.1:{port}"), None).unwrap();
     t.send(&LATEST_VERSION.to_be_bytes()).unwrap();
     let mut buf = [0u8; 4];
     t.receive(&mut buf).unwrap();
@@ -343,7 +343,7 @@ fn daemon_displays_motd() {
         .spawn()
         .unwrap();
     wait_for_daemon(port);
-    let mut t = TcpTransport::connect(&format!("127.0.0.1:{port}")).unwrap();
+    let mut t = TcpTransport::connect(&format!("127.0.0.1:{port}"), None).unwrap();
     t.send(&LATEST_VERSION.to_be_bytes()).unwrap();
     let mut buf = [0u8; 4];
     t.receive(&mut buf).unwrap();

--- a/tests/rsh.rs
+++ b/tests/rsh.rs
@@ -126,6 +126,7 @@ fn custom_rsh_negotiates_codecs() {
         Some(&remote_bin),
         None,
         true,
+        None,
     )
     .unwrap();
     drop(session);
@@ -164,10 +165,7 @@ fn rsh_parses_multi_argument_commands() {
 fn rsh_environment_variables_are_propagated() {
     let dir = tempdir().unwrap();
     let out = dir.path().join("env.txt");
-    let cmd = format!(
-        "FOO=bar sh -c 'echo \"$FOO\" > {}'",
-        out.display()
-    );
+    let cmd = format!("FOO=bar sh -c 'echo \"$FOO\" > {}'", out.display());
     let rsh = parse_rsh(Some(cmd)).unwrap();
     let mut c = Command::new(&rsh.cmd[0]);
     c.args(&rsh.cmd[1..]);

--- a/tests/timeout.rs
+++ b/tests/timeout.rs
@@ -1,0 +1,32 @@
+use std::io;
+use std::net::TcpListener;
+use std::thread;
+use std::time::Duration;
+
+use protocol::Demux;
+use transport::{TcpTransport, Transport};
+
+#[test]
+fn tcp_read_timeout() {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+    thread::spawn(move || {
+        let (_sock, _) = listener.accept().unwrap();
+        thread::sleep(Duration::from_secs(5));
+    });
+    let mut t = TcpTransport::connect(&addr.to_string(), None).unwrap();
+    t.set_read_timeout(Some(Duration::from_millis(100)))
+        .unwrap();
+    let mut buf = [0u8; 1];
+    let err = t.receive(&mut buf).err().expect("error");
+    assert!(err.kind() == io::ErrorKind::WouldBlock || err.kind() == io::ErrorKind::TimedOut);
+}
+
+#[test]
+fn demux_channel_timeout() {
+    let mut demux = Demux::new(Duration::from_millis(100));
+    demux.register_channel(0);
+    thread::sleep(Duration::from_millis(200));
+    let err = demux.poll().unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::TimedOut);
+}


### PR DESCRIPTION
## Summary
- parse `--timeout` and `--contimeout` flags into `Duration` fields for client and daemon
- apply I/O and connection timeouts to TCP and SSH transports and protocol server
- cover timeout behavior with regression tests and update docs

## Testing
- `cargo test -- --skip modern_negotiates_blake3_and_zstd` *(fails: rsh_parses_multi_argument_commands: Text file busy)*
- `cargo test --test timeout`


------
https://chatgpt.com/codex/tasks/task_e_68b211d9637083239f66bfa5157d9321