### PR TITLE
Handle creation times and ownership metadata

### DIFF
--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -788,14 +788,20 @@ impl Receiver {
                     }
                 },
                 chmod: self.opts.chmod.clone(),
+                owner: self.opts.owner,
+                group: self.opts.group,
+                perms: self.opts.perms,
+                times: self.opts.times,
+                atimes: self.opts.atimes,
+                crtimes: self.opts.crtimes,
             };
 
-            if self.opts.perms
-                || self.opts.times
-                || self.opts.atimes
-                || self.opts.crtimes
-                || self.opts.owner
-                || self.opts.group
+            if meta_opts.perms
+                || meta_opts.times
+                || meta_opts.atimes
+                || meta_opts.crtimes
+                || meta_opts.owner
+                || meta_opts.group
                 || meta_opts.xattrs
                 || meta_opts.acl
             {


### PR DESCRIPTION
## Summary
- track owner/group/permission/timestamp options in metadata
- propagate metadata options through engine receiver
- test mtime/atime/crtime/ownership roundtrips and defaults

## Testing
- `cargo test -p meta`
- `cargo test -p engine`


------
https://chatgpt.com/codex/tasks/task_e_68b21e495e848323b8c105f92315097a