### PR TITLE
Add daemon bandwidth limit and logging tests

### DIFF
--- a/tests/daemon_auth.sh
+++ b/tests/daemon_auth.sh
@@ -6,3 +6,5 @@ cargo test --test daemon -- --exact daemon_rejects_invalid_token
 cargo test --test daemon -- --exact daemon_rejects_unauthorized_module
 cargo test --test daemon -- --exact daemon_accepts_authorized_client
 cargo test --test daemon -- --exact client_respects_no_motd
+cargo test --test daemon -- --exact daemon_logs_connections
+cargo test --test daemon -- --exact daemon_honors_bwlimit


### PR DESCRIPTION
## Summary
- support `--bwlimit` for daemon mode and wrap connections with rate-limited transport
- log connections with custom formats and add coverage for log-file option
- add new daemon integration tests and update auth test script

## Testing
- `cargo test --test daemon -- --test-threads=1`
- `cargo test -p cli -- --test-threads=1`
- `bash tests/daemon_auth.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b2252b353c832398daa040778a19f1