### PR TITLE
Add checksum-choice flag with negotiation support

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -90,6 +90,14 @@ struct ClientOpts {
     /// use full checksums to determine file changes
     #[arg(short = 'c', long, help_heading = "Attributes")]
     checksum: bool,
+    /// choose the checksum algorithm (aka --cc)
+    #[arg(
+        long = "checksum-choice",
+        value_name = "STR",
+        help_heading = "Attributes",
+        visible_alias = "cc"
+    )]
+    checksum_choice: Option<String>,
     /// preserve permissions
     #[arg(long, help_heading = "Attributes")]
     perms: bool,
@@ -745,6 +753,47 @@ fn run_client(opts: ClientOpts, matches: &ArgMatches) -> Result<()> {
         rsync_env.push(("RSYNC_TIMEOUT".into(), to.as_secs().to_string()));
     }
 
+    if !rsync_env.iter().any(|(k, _)| k == "RSYNC_CHECKSUM_LIST") {
+        let mut list = vec!["md5", "sha1"];
+        if opts.modern || matches!(opts.checksum_choice.as_deref(), Some("blake3")) {
+            list.insert(0, "blake3");
+        }
+        rsync_env.push(("RSYNC_CHECKSUM_LIST".into(), list.join(",")));
+    }
+
+    let strong = if let Some(choice) = opts.checksum_choice.as_deref() {
+        match choice {
+            "md5" => StrongHash::Md5,
+            "sha1" => StrongHash::Sha1,
+            "blake3" => StrongHash::Blake3,
+            other => {
+                return Err(EngineError::Other(format!("unknown checksum {other}")));
+            }
+        }
+    } else if let Ok(list) = env::var("RSYNC_CHECKSUM_LIST") {
+        let mut chosen = StrongHash::Md5;
+        for name in list.split(',') {
+            match name {
+                "blake3" if opts.modern => {
+                    chosen = StrongHash::Blake3;
+                    break;
+                }
+                "sha1" => {
+                    chosen = StrongHash::Sha1;
+                    break;
+                }
+                "md5" => {
+                    chosen = StrongHash::Md5;
+                    break;
+                }
+                _ => {}
+            }
+        }
+        chosen
+    } else {
+        StrongHash::Md5
+    };
+
     let src_trailing = match &src {
         RemoteSpec::Local(p) => p.trailing_slash,
         RemoteSpec::Remote { path, .. } => path.trailing_slash,
@@ -850,11 +899,7 @@ fn run_client(opts: ClientOpts, matches: &ArgMatches) -> Result<()> {
         #[cfg(feature = "acl")]
         acls: opts.acls,
         sparse: opts.sparse,
-        strong: if opts.modern {
-            StrongHash::Blake3
-        } else {
-            StrongHash::Md5
-        },
+        strong,
         compress_level: opts.compress_level,
         compress_choice,
         partial: opts.partial || opts.partial_progress,
@@ -1633,6 +1678,14 @@ mod tests {
         assert!(opts.compress);
         assert!(opts.stats);
         assert_eq!(opts.config, Some(PathBuf::from("file")));
+    }
+
+    #[test]
+    fn parses_checksum_choice_and_alias() {
+        let opts = ClientOpts::parse_from(["prog", "--checksum-choice", "sha1", "src", "dst"]);
+        assert_eq!(opts.checksum_choice.as_deref(), Some("sha1"));
+        let opts = ClientOpts::parse_from(["prog", "--cc", "md5", "src", "dst"]);
+        assert_eq!(opts.checksum_choice.as_deref(), Some("md5"));
     }
 
     #[test]

--- a/docs/cli/flags.md
+++ b/docs/cli/flags.md
@@ -151,7 +151,7 @@
 |  | --backup-dir=DIR | make backups into hierarchy based in DIR | yes |  | no |
 | -B | --block-size=SIZE | force a fixed checksum block-size | no |  | no |
 | -c | --checksum | skip based on checksum, not mod-time & size | no | Parsed but not implemented | no |
-|  | --checksum-choice=STR | choose the checksum algorithm (aka --cc) | no |  | no |
+|  | --checksum-choice=STR | choose the checksum algorithm (aka --cc) | yes |  | no |
 |  | --checksum-seed=NUM | set block/file checksum seed (advanced) | no |  | no |
 |  | --compare-dest=DIR | also compare destination files relative to DIR | yes |  | no |
 |  | --contimeout=SECONDS | set daemon connection timeout in seconds | yes |  | no |

--- a/docs/feature_matrix.md
+++ b/docs/feature_matrix.md
@@ -17,9 +17,9 @@ See [differences.md](differences.md) for a summary of notable behavioral differe
 | `--block-size` | `-B` | ✅ | ❌ | — | controls delta block size | ≤3.2 |
 | `--blocking-io` | — | ❌ | — | — |  | ≤3.2 |
 | `--bwlimit` | — | ✅ | ❌ | [crates/transport/tests/bwlimit.rs](../crates/transport/tests/bwlimit.rs) |  | ≤3.2 |
-| `--cc` | — | ❌ | — | [gaps.md](gaps.md) | alias for `--checksum-choice` | ≤3.2 |
+| `--cc` | — | ✅ | ✅ | [tests/golden/cli_parity/checksum-choice.sh](../tests/golden/cli_parity/checksum-choice.sh) | alias for `--checksum-choice` | ≤3.2 |
 | `--checksum` | `-c` | ✅ | ✅ | [tests/cli.rs](../tests/cli.rs) | strong hashes: MD5 (default), SHA-1, BLAKE3 | ≤3.2 |
-| `--checksum-choice` | — | ❌ | — | — |  | ≤3.2 |
+| `--checksum-choice` | — | ✅ | ✅ | [tests/golden/cli_parity/checksum-choice.sh](../tests/golden/cli_parity/checksum-choice.sh) | choose the strong hash algorithm | ≤3.2 |
 | `--checksum-seed` | — | ❌ | — | — |  | ≤3.2 |
 | `--chmod` | — | ❌ | — | — |  | ≤3.2 |
 | `--chown` | — | ❌ | — | — |  | ≤3.2 |

--- a/tests/golden/cli_parity/checksum-choice.sh
+++ b/tests/golden/cli_parity/checksum-choice.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+RSYNC_RS="$ROOT/target/debug/rsync-rs"
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+mkdir -p "$TMP/src" "$TMP/rsync_dst" "$TMP/rsync_rs_dst"
+
+echo data > "$TMP/src/a.txt"
+
+RSYNC_CHECKSUM_LIST=sha1 rsync_output=$(rsync --quiet --recursive --checksum "$TMP/src/" "$TMP/rsync_dst" 2>&1)
+rsync_status=$?
+RSYNC_CHECKSUM_LIST=sha1 rsync_rs_raw=$("$RSYNC_RS" --local --recursive --checksum "$TMP/src/" "$TMP/rsync_rs_dst" 2>&1)
+rsync_rs_status=$?
+rsync_rs_output=$(echo "$rsync_rs_raw" | grep -v -e 'recursive mode enabled' || true)
+
+if [ "$rsync_status" -ne "$rsync_rs_status" ]; then
+  echo "Exit codes differ: rsync=$rsync_status rsync-rs=$rsync_rs_status" >&2
+  exit 1
+fi
+
+if [ "$rsync_output" != "$rsync_rs_output" ]; then
+  echo "Outputs differ" >&2
+  diff -u <(printf "%s" "$rsync_output") <(printf "%s" "$rsync_rs_output") >&2 || true
+  exit 1
+fi
+
+if ! diff -r "$TMP/rsync_dst" "$TMP/rsync_rs_dst" >/dev/null; then
+  echo "Directory trees differ" >&2
+  diff -r "$TMP/rsync_dst" "$TMP/rsync_rs_dst" >&2 || true
+  exit 1
+fi
+
+rm -rf "$TMP/rsync_dst" "$TMP/rsync_rs_dst"
+mkdir -p "$TMP/rsync_dst" "$TMP/rsync_rs_dst"
+
+rsync_output=$(rsync --quiet --recursive --checksum --cc=sha1 "$TMP/src/" "$TMP/rsync_dst" 2>&1)
+rsync_status=$?
+
+rsync_rs_raw=$("$RSYNC_RS" --local --recursive --checksum --cc=sha1 "$TMP/src/" "$TMP/rsync_rs_dst" 2>&1)
+rsync_rs_status=$?
+rsync_rs_output=$(echo "$rsync_rs_raw" | grep -v -e 'recursive mode enabled' || true)
+
+if [ "$rsync_status" -ne "$rsync_rs_status" ]; then
+  echo "Exit codes differ: rsync=$rsync_status rsync-rs=$rsync_rs_status" >&2
+  exit 1
+fi
+
+if [ "$rsync_output" != "$rsync_rs_output" ]; then
+  echo "Outputs differ" >&2
+  diff -u <(printf "%s" "$rsync_output") <(printf "%s" "$rsync_rs_output") >&2 || true
+  exit 1
+fi
+
+if ! diff -r "$TMP/rsync_dst" "$TMP/rsync_rs_dst" >/dev/null; then
+  echo "Directory trees differ" >&2
+  diff -r "$TMP/rsync_dst" "$TMP/rsync_rs_dst" >&2 || true
+  exit 1
+fi

--- a/tools/flag_matrix.json
+++ b/tools/flag_matrix.json
@@ -66,7 +66,7 @@
   },
   {
     "flag": "--checksum-choice",
-    "status": "Error",
+    "status": "Supported",
     "notes": ""
   },
   {

--- a/tools/flag_matrix.md
+++ b/tools/flag_matrix.md
@@ -13,7 +13,7 @@
 | --blocking-io | Error |  |
 | --bwlimit | Error |  |
 | --checksum | Supported |  |
-| --checksum-choice | Error |  |
+| --checksum-choice | Supported |  |
 | --checksum-seed | Error |  |
 | --chmod | Error |  |
 | --chown | Error |  |


### PR DESCRIPTION
## Summary
- support `--checksum-choice` flag with alias `--cc`
- negotiate strong hash via `RSYNC_CHECKSUM_LIST` and default to MD5
- add golden test for checksum-choice negotiation and alias

## Testing
- `cargo test` *(fails: test `modern_negotiates_blake3_and_zstd` hung after 60s)*
- `tests/golden/cli_parity/checksum-choice.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b22604e0dc83239f8935ce6abbbee6