### PR TITLE
Support custom RSYNC_RSH env with remote path override

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -741,6 +741,13 @@ fn run_client(opts: ClientOpts, matches: &ArgMatches) -> Result<()> {
     let mut rsync_env: Vec<(String, String)> = env::vars()
         .filter(|(k, _)| k.starts_with("RSYNC_"))
         .collect();
+    rsync_env.extend(
+        rsh_cmd
+            .env
+            .iter()
+            .filter(|(k, _)| k.starts_with("RSYNC_"))
+            .cloned(),
+    );
     if let Some(to) = opts.timeout {
         rsync_env.push(("RSYNC_TIMEOUT".into(), to.as_secs().to_string()));
     }


### PR DESCRIPTION
## Summary
- forward RSYNC_* variables parsed from `--rsh`/`RSYNC_RSH` into the remote handshake
- add regression test covering `--rsync-path` with `RSYNC_RSH`

## Testing
- `cargo test --test rsh`


------
https://chatgpt.com/codex/tasks/task_e_68b22663c6f88323bc5f5a499d4c1ad3