### PR TITLE
Add temp-dir option for temporary file placement

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -176,6 +176,14 @@ struct ClientOpts {
     /// put a partially transferred file into DIR
     #[arg(long = "partial-dir", value_name = "DIR", help_heading = "Misc")]
     partial_dir: Option<PathBuf>,
+    /// create temporary files in directory DIR
+    #[arg(
+        short = 'T',
+        long = "temp-dir",
+        value_name = "DIR",
+        help_heading = "Misc"
+    )]
+    temp_dir: Option<PathBuf>,
     /// show progress during transfer
     #[arg(long, help_heading = "Misc")]
     progress: bool,
@@ -908,6 +916,7 @@ fn run_client(opts: ClientOpts, matches: &ArgMatches) -> Result<()> {
         partial: opts.partial || opts.partial_progress,
         progress: opts.progress || opts.partial_progress,
         partial_dir: opts.partial_dir.clone(),
+        temp_dir: opts.temp_dir.clone(),
         append: opts.append,
         append_verify: opts.append_verify,
         numeric_ids: opts.numeric_ids,

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -120,6 +120,30 @@ fn resumes_from_partial_file() {
 }
 
 #[test]
+fn fails_when_temp_dir_is_file() {
+    let dir = tempdir().unwrap();
+    let src_dir = dir.path().join("src");
+    let dst_dir = dir.path().join("dst");
+    let tmp_file = dir.path().join("tmp");
+    std::fs::create_dir_all(&src_dir).unwrap();
+    std::fs::write(src_dir.join("a.txt"), b"hello").unwrap();
+    std::fs::create_dir_all(&dst_dir).unwrap();
+    std::fs::write(&tmp_file, b"not a dir").unwrap();
+
+    let mut cmd = Command::cargo_bin("rsync-rs").unwrap();
+    let src_arg = format!("{}/", src_dir.display());
+    cmd.args([
+        "--local",
+        "--temp-dir",
+        tmp_file.to_str().unwrap(),
+        &src_arg,
+        dst_dir.to_str().unwrap(),
+    ]);
+    cmd.assert().failure();
+    assert!(!dst_dir.join("a.txt").exists());
+}
+
+#[test]
 fn numeric_ids_are_preserved() {
     let dir = tempdir().unwrap();
     let src_dir = dir.path().join("src");


### PR DESCRIPTION
## Summary
- support `--temp-dir` flag in CLI and forward to engine
- allow engine to create temp files in user-specified directory
- test `temp-dir` flag handling in CLI

## Testing
- `cargo test --test cli`

------
https://chatgpt.com/codex/tasks/task_e_68b229c2e1988323a9823faa8470730b