### PR TITLE
Add configurable port handling for daemon and transports

### DIFF
--- a/crates/transport/tests/tcp.rs
+++ b/crates/transport/tests/tcp.rs
@@ -17,7 +17,8 @@ fn send_receive_over_tcp() {
         stream.write_all(&buf).unwrap();
     });
 
-    let mut transport = TcpTransport::connect(&addr.to_string(), None).expect("connect");
+    let mut transport =
+        TcpTransport::connect(&addr.ip().to_string(), addr.port(), None).expect("connect");
     transport.send(b"ping").expect("send");
     let mut buf = [0u8; 4];
     let n = transport.receive(&mut buf).expect("receive");

--- a/tests/rsh.rs
+++ b/tests/rsh.rs
@@ -127,6 +127,7 @@ fn custom_rsh_negotiates_codecs() {
         None,
         true,
         None,
+        None,
     )
     .unwrap();
     drop(session);

--- a/tests/timeout.rs
+++ b/tests/timeout.rs
@@ -14,7 +14,7 @@ fn tcp_read_timeout() {
         let (_sock, _) = listener.accept().unwrap();
         thread::sleep(Duration::from_secs(5));
     });
-    let mut t = TcpTransport::connect(&addr.to_string(), None).unwrap();
+    let mut t = TcpTransport::connect(&addr.ip().to_string(), addr.port(), None).unwrap();
     t.set_read_timeout(Some(Duration::from_millis(100)))
         .unwrap();
     let mut buf = [0u8; 1];


### PR DESCRIPTION
## Summary
- allow specifying remote port via `--port`
- support port in TCP and SSH transports
- test daemon connectivity on ephemeral ports

## Testing
- `cargo test`
- `cargo test --test daemon`


------
https://chatgpt.com/codex/tasks/task_e_68b229bb5b348323b9871718c20ae51c