### PR TITLE
feat: add whole file transfer option

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -222,6 +222,21 @@ struct ClientOpts {
         help_heading = "Misc"
     )]
     block_size: Option<usize>,
+    /// copy files whole (w/o delta-xfer algorithm)
+    #[arg(
+        short = 'W',
+        long,
+        help_heading = "Misc",
+        overrides_with = "no_whole_file"
+    )]
+    whole_file: bool,
+    /// disable whole-file transfer
+    #[arg(
+        long = "no-whole-file",
+        help_heading = "Misc",
+        overrides_with = "whole_file"
+    )]
+    no_whole_file: bool,
     /// hardlink to files in DIR when unchanged
     #[arg(long = "link-dest", value_name = "DIR", help_heading = "Misc")]
     link_dest: Option<PathBuf>,
@@ -928,6 +943,11 @@ fn run_client(opts: ClientOpts, matches: &ArgMatches) -> Result<()> {
         strong,
         compress_level: opts.compress_level,
         compress_choice,
+        whole_file: if opts.no_whole_file {
+            false
+        } else {
+            opts.whole_file
+        },
         partial: opts.partial || opts.partial_progress,
         progress: opts.progress || opts.partial_progress,
         itemize_changes: opts.itemize_changes,


### PR DESCRIPTION
## Summary
- support `--whole-file` and `--no-whole-file` flags in CLI
- allow engine to bypass delta algorithm when whole-file mode is active
- test whole-file flag copies files directly

## Testing
- `cargo test` (fails: tests/modern.rs hung >60s)
- `cargo test --test modern -- --nocapture` (hung >60s, aborted)


------
https://chatgpt.com/codex/tasks/task_e_68b22f8fb39083239cedf92f48e5279d