### PR TITLE
Add copy-dirlinks option and symlink handling

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -128,6 +128,9 @@ struct ClientOpts {
     /// transform symlink into referent file/dir
     #[arg(short = 'L', long, help_heading = "Attributes")]
     copy_links: bool,
+    /// transform symlink to directory into referent
+    #[arg(short = 'k', long, help_heading = "Attributes")]
+    copy_dirlinks: bool,
     /// only "unsafe" symlinks are transformed
     #[arg(long, help_heading = "Attributes")]
     copy_unsafe_links: bool,
@@ -223,10 +226,20 @@ struct ClientOpts {
     #[arg(long, value_name = "PORT", help_heading = "Misc")]
     port: Option<u16>,
     /// prefer IPv4 for remote connections
-    #[arg(short = '4', long = "ipv4", help_heading = "Misc", conflicts_with = "ipv6")]
+    #[arg(
+        short = '4',
+        long = "ipv4",
+        help_heading = "Misc",
+        conflicts_with = "ipv6"
+    )]
     ipv4: bool,
     /// prefer IPv6 for remote connections
-    #[arg(short = '6', long = "ipv6", help_heading = "Misc", conflicts_with = "ipv4")]
+    #[arg(
+        short = '6',
+        long = "ipv6",
+        help_heading = "Misc",
+        conflicts_with = "ipv4"
+    )]
     ipv6: bool,
     /// set block size used for rolling checksums
     #[arg(
@@ -952,6 +965,7 @@ fn run_client(opts: ClientOpts, matches: &ArgMatches) -> Result<()> {
         group: opts.group || opts.archive,
         links: opts.links || opts.archive,
         copy_links: opts.copy_links,
+        copy_dirlinks: opts.copy_dirlinks,
         copy_unsafe_links: opts.copy_unsafe_links,
         safe_links: opts.safe_links,
         hard_links: opts.hard_links,

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -862,6 +862,7 @@ pub struct SyncOptions {
     pub group: bool,
     pub links: bool,
     pub copy_links: bool,
+    pub copy_dirlinks: bool,
     pub copy_unsafe_links: bool,
     pub safe_links: bool,
     pub hard_links: bool,
@@ -911,6 +912,7 @@ impl Default for SyncOptions {
             group: false,
             links: false,
             copy_links: false,
+            copy_dirlinks: false,
             copy_unsafe_links: false,
             safe_links: false,
             hard_links: false,
@@ -1128,7 +1130,11 @@ pub fn sync(
                         continue;
                     }
                     let meta = fs::metadata(&target_path).ok();
-                    if opts.copy_links || (opts.copy_unsafe_links && is_unsafe) {
+                    if opts.copy_links
+                        || (opts.copy_dirlinks
+                            && meta.as_ref().map(|m| m.is_dir()).unwrap_or(false))
+                        || (opts.copy_unsafe_links && is_unsafe)
+                    {
                         if let Some(meta) = meta {
                             if meta.is_dir() {
                                 if let Some(parent) = dest_path.parent() {

--- a/docs/feature_matrix.md
+++ b/docs/feature_matrix.md
@@ -33,9 +33,9 @@ See [differences.md](differences.md) for a summary of notable behavioral differe
 | `--copy-as` | — | ❌ | — | — |  | ≤3.2 |
 | `--copy-dest` | — | ✅ | ✅ | [tests/link_copy_compare_dest.rs](../tests/link_copy_compare_dest.rs) |  | ≤3.2 |
 | `--copy-devices` | — | ❌ | — | — |  | ≤3.2 |
-| `--copy-dirlinks` | `-k` | ❌ | — | — |  | ≤3.2 |
-| `--copy-links` | `-L` | ❌ | — | — |  | ≤3.2 |
-| `--copy-unsafe-links` | — | ❌ | — | — |  | ≤3.2 |
+| `--copy-dirlinks` | `-k` | ✅ | ✅ | [tests/golden/cli_parity/copy-dirlinks.sh](../tests/golden/cli_parity/copy-dirlinks.sh) |  | ≤3.2 |
+| `--copy-links` | `-L` | ✅ | ❌ | [tests/symlink_resolution.rs](../tests/symlink_resolution.rs) |  | ≤3.2 |
+| `--copy-unsafe-links` | — | ✅ | ❌ | [tests/symlink_resolution.rs](../tests/symlink_resolution.rs) |  | ≤3.2 |
 | `--crtimes` | `-N` | ✅ | ❌ | [crates/engine/tests/attrs.rs](../crates/engine/tests/attrs.rs) |  | ≤3.2 |
 | `--cvs-exclude` | `-C` | ❌ | — | — |  | ≤3.2 |
 | `--daemon` | — | ✅ | ❌ | [tests/daemon.rs](../tests/daemon.rs) |  | ≤3.2 |
@@ -128,7 +128,7 @@ See [differences.md](differences.md) for a summary of notable behavioral differe
 | `--remove-source-files` | — | ❌ | — | — |  | ≤3.2 |
 | `--rsh` | `-e` | ⚠️ | ❌ | [tests/rsh.rs](../tests/rsh.rs) | negotiation incomplete; lacks full command parsing and environment handshake | ≤3.2 |
 | `--rsync-path` | — | ⚠️ | ❌ | [tests/rsync_path.rs](../tests/rsync_path.rs) | requires `--rsh`; remote path negotiation incomplete | ≤3.2 |
-| `--safe-links` | — | ❌ | — | — |  | ≤3.2 |
+| `--safe-links` | — | ✅ | ❌ | [tests/symlink_resolution.rs](../tests/symlink_resolution.rs) |  | ≤3.2 |
 | `--secluded-args` | `-s` | ❌ | — | — |  | ≤3.2 |
 | `--secrets-file` | — | ✅ | ❌ | [tests/daemon.rs](../tests/daemon.rs) |  | ≤3.2 |
 | `--server` | — | ✅ | ❌ | [tests/server.rs](../tests/server.rs) | negotiates protocol version and codecs | ≤3.2 |

--- a/tests/golden/cli_parity/copy-dirlinks.sh
+++ b/tests/golden/cli_parity/copy-dirlinks.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+RSYNC_RS="$ROOT/target/debug/rsync-rs"
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+mkdir -p "$TMP/src" "$TMP/rsync_dst" "$TMP/rsync_rs_dst"
+
+mkdir -p "$TMP/src/dir"
+echo data > "$TMP/src/dir/file"
+ln -s dir "$TMP/src/dirlink"
+ln -s dir/file "$TMP/src/filelink"
+
+rsync_output=$(rsync --quiet --recursive --links --copy-dirlinks "$TMP/src/" "$TMP/rsync_dst" 2>&1)
+rsync_status=$?
+
+rsync_rs_raw=$("$RSYNC_RS" --local --recursive --links --copy-dirlinks "$TMP/src/" "$TMP/rsync_rs_dst" 2>&1)
+rsync_rs_status=$?
+rsync_rs_output=$(echo "$rsync_rs_raw" | grep -v -e 'recursive mode enabled' || true)
+
+if [ "$rsync_status" -ne "$rsync_rs_status" ]; then
+  echo "Exit codes differ: rsync=$rsync_status rsync-rs=$rsync_rs_status" >&2
+  exit 1
+fi
+
+if [ "$rsync_output" != "$rsync_rs_output" ]; then
+  echo "Outputs differ" >&2
+  diff -u <(printf "%s" "$rsync_output") <(printf "%s" "$rsync_rs_output") >&2 || true
+  exit 1
+fi
+
+if ! diff -r "$TMP/rsync_dst" "$TMP/rsync_rs_dst" >/dev/null; then
+  echo "Directory trees differ" >&2
+  diff -r "$TMP/rsync_dst" "$TMP/rsync_rs_dst" >&2 || true
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- support `--copy-dirlinks` to transform directory symlinks
- document and test symlink options

## Testing
- `cargo test` *(fails: remote_remote_via_ssh_paths hung)*
- `bash tests/golden/cli_parity/copy-dirlinks.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b2b08a09e48323a7688f293d8880a9