### PR TITLE
Support composite remote shells and rsync-path forwarding

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -302,7 +302,7 @@ struct ClientOpts {
     sender: bool,
     /// specify the rsync to run on remote machine
     #[arg(long = "rsync-path", value_name = "PATH", alias = "rsync_path")]
-    rsync_path: Option<PathBuf>,
+    rsync_path: Option<String>,
     /// source path or HOST:PATH
     src: String,
     /// destination path or HOST:PATH
@@ -499,6 +499,20 @@ pub fn parse_rsh(raw: Option<String>) -> Result<RshCommand> {
     }
 
     Ok(RshCommand { env, cmd })
+}
+
+pub fn parse_rsync_path(raw: Option<String>) -> Result<Option<Vec<String>>> {
+    match raw {
+        Some(s) => {
+            let parts = shell_split(&s).map_err(|e| EngineError::Other(e.to_string()))?;
+            if parts.is_empty() {
+                Ok(None)
+            } else {
+                Ok(Some(parts))
+            }
+        }
+        None => Ok(None),
+    }
 }
 
 /// Options for daemon mode.
@@ -815,6 +829,7 @@ fn run_client(opts: ClientOpts, matches: &ArgMatches) -> Result<()> {
     let strict_host_key_checking = !opts.no_host_key_checking;
     let rsh_raw = opts.rsh.clone().or_else(|| env::var("RSYNC_RSH").ok());
     let rsh_cmd = parse_rsh(rsh_raw)?;
+    let rsync_path_cmd = parse_rsync_path(opts.rsync_path.clone())?;
     let mut rsync_env: Vec<(String, String)> = env::vars()
         .filter(|(k, _)| k.starts_with("RSYNC_"))
         .collect();
@@ -1065,7 +1080,7 @@ fn run_client(opts: ClientOpts, matches: &ArgMatches) -> Result<()> {
                     &rsh_cmd.cmd,
                     &rsh_cmd.env,
                     &rsync_env,
-                    opts.rsync_path.as_deref(),
+                    rsync_path_cmd.as_deref(),
                     known_hosts.as_deref(),
                     strict_host_key_checking,
                     opts.port,
@@ -1119,7 +1134,7 @@ fn run_client(opts: ClientOpts, matches: &ArgMatches) -> Result<()> {
                     &rsh_cmd.cmd,
                     &rsh_cmd.env,
                     &rsync_env,
-                    opts.rsync_path.as_deref(),
+                    rsync_path_cmd.as_deref(),
                     known_hosts.as_deref(),
                     strict_host_key_checking,
                     opts.port,
@@ -1161,7 +1176,7 @@ fn run_client(opts: ClientOpts, matches: &ArgMatches) -> Result<()> {
                             &dst_path.path,
                             &rsh_cmd.cmd,
                             &rsh_cmd.env,
-                            opts.rsync_path.as_deref(),
+                            rsync_path_cmd.as_deref(),
                             known_hosts.as_deref(),
                             strict_host_key_checking,
                             opts.port,
@@ -1174,7 +1189,7 @@ fn run_client(opts: ClientOpts, matches: &ArgMatches) -> Result<()> {
                             &src_path.path,
                             &rsh_cmd.cmd,
                             &rsh_cmd.env,
-                            opts.rsync_path.as_deref(),
+                            rsync_path_cmd.as_deref(),
                             known_hosts.as_deref(),
                             strict_host_key_checking,
                             opts.port,
@@ -1255,7 +1270,7 @@ fn run_client(opts: ClientOpts, matches: &ArgMatches) -> Result<()> {
                             &dst_path.path,
                             &rsh_cmd.cmd,
                             &rsh_cmd.env,
-                            opts.rsync_path.as_deref(),
+                            rsync_path_cmd.as_deref(),
                             known_hosts.as_deref(),
                             strict_host_key_checking,
                             opts.port,
@@ -1312,7 +1327,7 @@ fn run_client(opts: ClientOpts, matches: &ArgMatches) -> Result<()> {
                             &src_path.path,
                             &rsh_cmd.cmd,
                             &rsh_cmd.env,
-                            opts.rsync_path.as_deref(),
+                            rsync_path_cmd.as_deref(),
                             known_hosts.as_deref(),
                             strict_host_key_checking,
                             opts.port,
@@ -1821,9 +1836,9 @@ mod tests {
     #[test]
     fn parses_rsync_path_and_alias() {
         let opts = ClientOpts::parse_from(["prog", "--rsync-path", "/bin/rsync", "src", "dst"]);
-        assert_eq!(opts.rsync_path, Some(PathBuf::from("/bin/rsync")));
+        assert_eq!(opts.rsync_path.as_deref(), Some("/bin/rsync"));
         let opts = ClientOpts::parse_from(["prog", "--rsync_path", "/bin/rsync", "src", "dst"]);
-        assert_eq!(opts.rsync_path, Some(PathBuf::from("/bin/rsync")));
+        assert_eq!(opts.rsync_path.as_deref(), Some("/bin/rsync"));
     }
 
     #[test]

--- a/crates/transport/src/ssh.rs
+++ b/crates/transport/src/ssh.rs
@@ -256,7 +256,7 @@ impl SshStdioTransport {
         path: &Path,
         rsh: &[String],
         rsh_env: &[(String, String)],
-        remote_bin: Option<&Path>,
+        remote_bin: Option<&[String]>,
         known_hosts: Option<&Path>,
         strict_host_key_checking: bool,
         port: Option<u16>,
@@ -298,7 +298,7 @@ impl SshStdioTransport {
             }
             cmd.arg(host);
             if let Some(bin) = remote_bin {
-                cmd.arg(bin);
+                cmd.args(bin);
             } else {
                 cmd.arg("rsync");
             }
@@ -314,7 +314,7 @@ impl SshStdioTransport {
             };
             args.push(host);
             if let Some(bin) = remote_bin {
-                args.push(bin.to_string_lossy().into_owned());
+                args.extend_from_slice(bin);
             } else {
                 args.push("rsync".to_string());
             }
@@ -333,7 +333,7 @@ impl SshStdioTransport {
         rsh: &[String],
         rsh_env: &[(String, String)],
         rsync_env: &[(String, String)],
-        remote_bin: Option<&Path>,
+        remote_bin: Option<&[String]>,
         known_hosts: Option<&Path>,
         strict_host_key_checking: bool,
         port: Option<u16>,

--- a/tests/rsh.rs
+++ b/tests/rsh.rs
@@ -109,6 +109,7 @@ fn custom_rsh_negotiates_codecs() {
     let remote_bin = dir.path().join("rr-remote");
     fs::copy(cargo_bin("rsync-rs"), &remote_bin).unwrap();
     fs::set_permissions(&remote_bin, fs::Permissions::from_mode(0o755)).unwrap();
+    let remote_cmd = vec![remote_bin.to_str().unwrap().to_string()];
 
     let rsh = dir.path().join("fake_rsh.sh");
     fs::write(&rsh, b"#!/bin/sh\nshift\nexec \"$@\"\n").unwrap();
@@ -125,7 +126,7 @@ fn custom_rsh_negotiates_codecs() {
         &rsh_cmd,
         &rsh_env,
         &rsync_env,
-        Some(&remote_bin),
+        Some(&remote_cmd),
         None,
         true,
         None,
@@ -177,6 +178,47 @@ fn rsh_environment_variables_are_propagated() {
     c.status().unwrap();
     let content = fs::read_to_string(&out).unwrap();
     assert_eq!(content.trim(), "bar");
+}
+
+#[cfg(unix)]
+#[test]
+fn rsh_env_var_assignments_are_honored() {
+    let dir = tempdir().unwrap();
+    let src_dir = dir.path().join("src");
+    fs::create_dir(&src_dir).unwrap();
+    let src_file = src_dir.join("file.txt");
+    fs::write(&src_file, b"via env").unwrap();
+    let dst_dir = dir.path().join("dst");
+
+    let out = dir.path().join("env.txt");
+    let rsh = dir.path().join("fake_rsh.sh");
+    fs::write(
+        &rsh,
+        format!("#!/bin/sh\necho \"$FOO\" > {}\nshift\nexec \"$@\"\n", out.display()),
+    )
+    .unwrap();
+    fs::set_permissions(&rsh, fs::Permissions::from_mode(0o755)).unwrap();
+
+    let remote_bin = dir.path().join("rr-remote");
+    fs::copy(cargo_bin("rsync-rs"), &remote_bin).unwrap();
+    fs::set_permissions(&remote_bin, fs::Permissions::from_mode(0o755)).unwrap();
+
+    let src_spec = format!("{}/", src_dir.display());
+    let dst_spec = format!("ignored:{}", dst_dir.display());
+    let rsh_spec = format!("FOO=bar {}", rsh.display());
+    let mut cmd = AssertCommand::cargo_bin("rsync-rs").unwrap();
+    cmd.env("RSYNC_RSH", rsh_spec);
+    cmd.args([
+        "--rsync-path",
+        remote_bin.to_str().unwrap(),
+        "-r",
+        &src_spec,
+        &dst_spec,
+    ]);
+    cmd.assert().success();
+
+    let env_out = fs::read_to_string(&out).unwrap();
+    assert_eq!(env_out.trim(), "bar");
 }
 
 #[cfg(unix)]

--- a/tests/rsync_path.rs
+++ b/tests/rsync_path.rs
@@ -43,3 +43,55 @@ fn custom_rsync_path_performs_transfer() {
     let out = fs::read(dst_dir.join("file.txt")).unwrap();
     assert_eq!(out, b"from custom binary");
 }
+
+#[cfg(unix)]
+#[test]
+fn rsync_path_supports_wrapper_command() {
+    let dir = tempdir().unwrap();
+    let src_dir = dir.path().join("src");
+    fs::create_dir(&src_dir).unwrap();
+    let src_file = src_dir.join("file.txt");
+    fs::write(&src_file, b"wrapped").unwrap();
+    let dst_dir = dir.path().join("dst");
+
+    let remote_bin = dir.path().join("rr-remote");
+    fs::copy(assert_cmd::cargo::cargo_bin("rsync-rs"), &remote_bin).unwrap();
+    fs::set_permissions(&remote_bin, fs::Permissions::from_mode(0o755)).unwrap();
+
+    let marker = dir.path().join("marker.txt");
+    let wrapper = dir.path().join("wrapper.sh");
+    fs::write(
+        &wrapper,
+        format!(
+            "#!/bin/sh\ntouch {}\nexec {} \"$@\"\n",
+            marker.display(),
+            remote_bin.display()
+        ),
+    )
+    .unwrap();
+    fs::set_permissions(&wrapper, fs::Permissions::from_mode(0o755)).unwrap();
+
+    let rsync_path = format!("{} {}", wrapper.display(), remote_bin.display());
+
+    let rsh = dir.path().join("fake_rsh.sh");
+    fs::write(&rsh, b"#!/bin/sh\nshift\nexec \"$@\"\n").unwrap();
+    fs::set_permissions(&rsh, fs::Permissions::from_mode(0o755)).unwrap();
+
+    let src_spec = format!("{}/", src_dir.display());
+    let dst_spec = format!("ignored:{}", dst_dir.display());
+    let mut cmd = Command::cargo_bin("rsync-rs").unwrap();
+    cmd.args([
+        "-e",
+        rsh.to_str().unwrap(),
+        "--rsync-path",
+        &rsync_path,
+        "-r",
+        &src_spec,
+        &dst_spec,
+    ]);
+    cmd.assert().success();
+
+    assert!(marker.exists());
+    let out = fs::read(dst_dir.join("file.txt")).unwrap();
+    assert_eq!(out, b"wrapped");
+}


### PR DESCRIPTION
## Summary
- parse `--rsync-path` as a composite command and plumb it through the SSH transport
- allow remote shell and rsync path to include environment assignments and extra wrappers
- test exotic remote shells and wrapper-based remote rsync paths

## Testing
- `cargo test --tests` *(failed: remote_remote_via_ssh_paths exceeded 60s; run aborted)*
- `cargo test --test rsh --test rsync_path`


------
https://chatgpt.com/codex/tasks/task_e_68b2bc4b92748323bdd2676cec1d99a8