### PR TITLE
Expose RuleData for public Rule enum

### DIFF
--- a/crates/filters/src/lib.rs
+++ b/crates/filters/src/lib.rs
@@ -29,7 +29,7 @@ impl RuleFlags {
 }
 
 #[derive(Clone)]
-struct RuleData {
+pub struct RuleData {
     matcher: GlobMatcher,
     invert: bool,
     flags: RuleFlags,


### PR DESCRIPTION
## Summary
- Make `RuleData` public so `Rule` variants don't expose a private type

## Testing
- `cargo check`


------
https://chatgpt.com/codex/tasks/task_e_68b2d97431c48323b43cc4da5e1c764d