### PR TITLE
Fix relative filter traversal for rsync-style roots

### DIFF
--- a/crates/filters/src/lib.rs
+++ b/crates/filters/src/lib.rs
@@ -119,8 +119,12 @@ impl Matcher {
             let mut dirs = vec![root.clone()];
 
             if let Some(parent) = path.parent() {
+                let iter = match parent.strip_prefix(root) {
+                    Ok(rel) => rel.components(),
+                    Err(_) => parent.components(),
+                };
                 let mut dir = root.clone();
-                for comp in parent.components() {
+                for comp in iter {
                     dir.push(comp.as_os_str());
                     dirs.push(dir.clone());
                 }


### PR DESCRIPTION
## Summary
- ensure Matcher walks only directories beneath transfer root when loading per-dir filters

## Testing
- `cargo test --test filter_corpus -- filter_corpus_parity --nocapture`


------
https://chatgpt.com/codex/tasks/task_e_68b2d96bc1608323b0d48b61e4af06c0