### PR TITLE
Add CVS exclude support

### DIFF
--- a/crates/filters/src/lib.rs
+++ b/crates/filters/src/lib.rs
@@ -1,6 +1,7 @@
 use globset::{Glob, GlobMatcher};
 use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
+use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -279,7 +280,28 @@ impl Matcher {
             Err(_) => return Ok((Vec::new(), Vec::new())),
         };
 
-        let adjusted = if let Some(rel) = rel {
+        let adjusted = if path.file_name().map_or(false, |f| f == ".cvsignore") {
+            let rel_str = rel.map(|p| p.to_string_lossy().to_string());
+            let mut buf = String::new();
+            for token in content.split_whitespace() {
+                if token.starts_with('#') {
+                    continue;
+                }
+                let pat = if let Some(rel_str) = &rel_str {
+                    if token.starts_with('/') {
+                        format!("/{}/{}", rel_str, token.trim_start_matches('/'))
+                    } else {
+                        format!("{}/{}", rel_str, token)
+                    }
+                } else {
+                    token.to_string()
+                };
+                buf.push_str("- ");
+                buf.push_str(&pat);
+                buf.push('\n');
+            }
+            buf
+        } else if let Some(rel) = rel {
             let rel_str = rel.to_string_lossy();
             let mut buf = String::new();
             for raw_line in content.lines() {
@@ -472,7 +494,17 @@ pub fn parse(
         } else if let Some(r) = line.strip_prefix(':') {
             let (m, file) = split_mods(r, "-+Cenw/!srpx");
             if file.is_empty() {
-                return Err(ParseError::InvalidRule(raw_line.to_string()));
+                if m.contains('C') {
+                    rules.push(Rule::DirMerge(PerDir {
+                        file: ".cvsignore".into(),
+                        anchored: false,
+                        root_only: false,
+                        inherit: true,
+                    }));
+                    continue;
+                } else {
+                    return Err(ParseError::InvalidRule(raw_line.to_string()));
+                }
             }
             let anchored = file.starts_with('/') || m.contains('/');
             let fname = if anchored {
@@ -600,7 +632,7 @@ pub fn parse(
     Ok(rules)
 }
 
-const CVS_DEFAULTS: &[&str] = &[
+pub const CVS_DEFAULTS: &[&str] = &[
     "RCS",
     "SCCS",
     "CVS",
@@ -639,9 +671,8 @@ const CVS_DEFAULTS: &[&str] = &[
     ".bzr/",
 ];
 
-fn default_cvs_rules() -> Result<Vec<Rule>, ParseError> {
-    let mut out = Vec::new();
-    for pat in CVS_DEFAULTS {
+pub fn default_cvs_rules() -> Result<Vec<Rule>, ParseError> {
+    fn add_pat(out: &mut Vec<Rule>, pat: &str) -> Result<(), ParseError> {
         let dir_only = pat.ends_with('/');
         let mut base = pat.trim_end_matches('/').to_string();
         if !base.contains('/') {
@@ -664,6 +695,32 @@ fn default_cvs_rules() -> Result<Vec<Rule>, ParseError> {
             };
             out.push(Rule::Exclude(data));
         }
+        Ok(())
     }
+
+    let mut out = Vec::new();
+    for pat in CVS_DEFAULTS {
+        add_pat(&mut out, pat)?;
+    }
+
+    if let Ok(home) = env::var("HOME") {
+        let path = Path::new(&home).join(".cvsignore");
+        if let Ok(content) = fs::read_to_string(path) {
+            for pat in content.split_whitespace() {
+                if !pat.is_empty() {
+                    add_pat(&mut out, pat)?;
+                }
+            }
+        }
+    }
+
+    if let Ok(envpats) = env::var("CVSIGNORE") {
+        for pat in envpats.split_whitespace() {
+            if !pat.is_empty() {
+                add_pat(&mut out, pat)?;
+            }
+        }
+    }
+
     Ok(out)
 }

--- a/tests/cvs_exclude.rs
+++ b/tests/cvs_exclude.rs
@@ -1,0 +1,63 @@
+use assert_cmd::Command;
+use std::fs;
+use std::process::Command as StdCommand;
+use tempfile::tempdir;
+
+#[test]
+fn cvs_exclude_parity() {
+    let tmp = tempdir().unwrap();
+    let src = tmp.path().join("src");
+    fs::create_dir_all(&src).unwrap();
+    fs::create_dir_all(src.join(".git")).unwrap();
+    fs::write(src.join(".git/file"), "git").unwrap();
+    fs::write(src.join("keep.txt"), "keep").unwrap();
+    fs::write(src.join("core"), "core").unwrap();
+    fs::write(src.join("foo.o"), "obj").unwrap();
+    fs::write(src.join("env_ignored"), "env").unwrap();
+    fs::write(src.join("home_ignored"), "home").unwrap();
+    fs::write(src.join("local_ignored"), "local").unwrap();
+    fs::write(src.join(".cvsignore"), "local_ignored\n").unwrap();
+
+    let home = tempdir().unwrap();
+    fs::write(home.path().join(".cvsignore"), "home_ignored\n").unwrap();
+
+    let rsync_dst = tmp.path().join("rsync");
+    let ours_dst = tmp.path().join("ours");
+    fs::create_dir_all(&rsync_dst).unwrap();
+    fs::create_dir_all(&ours_dst).unwrap();
+
+    let src_arg = format!("{}/", src.display());
+
+    let mut rsync_cmd = StdCommand::new("rsync");
+    rsync_cmd.env("CVSIGNORE", "env_ignored");
+    rsync_cmd.env("HOME", home.path());
+    rsync_cmd.args(["-r", "--quiet", "--cvs-exclude"]);
+    rsync_cmd.arg(&src_arg);
+    rsync_cmd.arg(&rsync_dst);
+    let rsync_out = rsync_cmd.output().unwrap();
+    assert!(rsync_out.status.success());
+    let rsync_output = String::from_utf8_lossy(&rsync_out.stdout).to_string()
+        + &String::from_utf8_lossy(&rsync_out.stderr);
+
+    let mut ours_cmd = Command::cargo_bin("rsync-rs").unwrap();
+    ours_cmd.env("CVSIGNORE", "env_ignored");
+    ours_cmd.env("HOME", home.path());
+    ours_cmd.args(["--local", "--recursive", "--cvs-exclude"]);
+    ours_cmd.arg(&src_arg);
+    ours_cmd.arg(&ours_dst);
+    let ours_out = ours_cmd.output().unwrap();
+    assert!(ours_out.status.success());
+    let mut ours_output = String::from_utf8_lossy(&ours_out.stdout).to_string()
+        + &String::from_utf8_lossy(&ours_out.stderr);
+    ours_output = ours_output.replace("recursive mode enabled\n", "");
+
+    assert_eq!(rsync_output, ours_output);
+
+    let diff = StdCommand::new("diff")
+        .arg("-r")
+        .arg(&rsync_dst)
+        .arg(&ours_dst)
+        .output()
+        .unwrap();
+    assert!(diff.status.success(), "directory trees differ");
+}


### PR DESCRIPTION
## Summary
- add `--cvs-exclude` (`-C`) CLI flag and append default CVS patterns
- expose CVS ignore patterns and `.cvsignore` handling in filters
- test `--cvs-exclude` behavior against upstream rsync

## Testing
- `cargo test` *(fails: test `remote_remote_via_ssh_paths` exceeded 60s and was interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68b2d99e37e48323847a385fb169b6f4