### PR TITLE
Implement uid/gid mapping and high-res time parity

### DIFF
--- a/docs/feature_matrix.md
+++ b/docs/feature_matrix.md
@@ -36,7 +36,7 @@ See [differences.md](differences.md) for a summary of notable behavioral differe
 | `--copy-dirlinks` | `-k` | ✅ | ✅ | [tests/golden/cli_parity/copy-dirlinks.sh](../tests/golden/cli_parity/copy-dirlinks.sh) |  | ≤3.2 |
 | `--copy-links` | `-L` | ✅ | ❌ | [tests/symlink_resolution.rs](../tests/symlink_resolution.rs) |  | ≤3.2 |
 | `--copy-unsafe-links` | — | ✅ | ❌ | [tests/symlink_resolution.rs](../tests/symlink_resolution.rs) |  | ≤3.2 |
-| `--crtimes` | `-N` | ✅ | ❌ | [crates/engine/tests/attrs.rs](../crates/engine/tests/attrs.rs) |  | ≤3.2 |
+| `--crtimes` | `-N` | ✅ | ✅ | [crates/engine/tests/attrs.rs](../crates/engine/tests/attrs.rs) |  | ≤3.2 |
 | `--cvs-exclude` | `-C` | ❌ | — | — |  | ≤3.2 |
 | `--daemon` | — | ✅ | ❌ | [tests/daemon.rs](../tests/daemon.rs) |  | ≤3.2 |
 | `--debug` | — | ❌ | — | — |  | ≤3.2 |
@@ -64,7 +64,7 @@ See [differences.md](differences.md) for a summary of notable behavioral differe
 | `--from0` | `-0` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  | ≤3.2 |
 | `--fsync` | — | ❌ | — | — |  | ≤3.2 |
 | `--fuzzy` | `-y` | ❌ | — | — |  | ≤3.2 |
-| `--group` | `-g` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  | ≤3.2 |
+| `--group` | `-g` | ✅ | ✅ | [crates/engine/tests/attrs.rs](../crates/engine/tests/attrs.rs) |  | ≤3.2 |
 | `--groupmap` | — | ❌ | — | — |  | ≤3.2 |
 | `--hard-links` | `-H` | ✅ | ❌ | [tests/local_sync_tree.rs](../tests/local_sync_tree.rs) |  | ≤3.2 |
 | `--help` | `-h (*)` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  | ≤3.2 |
@@ -110,7 +110,7 @@ See [differences.md](differences.md) for a summary of notable behavioral differe
 | `--open-noatime` | — | ❌ | — | — |  | ≤3.2 |
 | `--out-format` | — | ❌ | — | — |  | ≤3.2 |
 | `--outbuf` | — | ❌ | — | — |  | ≤3.2 |
-| `--owner` | `-o` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  | ≤3.2 |
+| `--owner` | `-o` | ✅ | ✅ | [crates/engine/tests/attrs.rs](../crates/engine/tests/attrs.rs) |  | ≤3.2 |
 | `--partial` | — | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  | ≤3.2 |
 | `--partial-dir` | — | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  | ≤3.2 |
 | `--password-file` | — | ✅ | ❌ | [tests/daemon.rs](../tests/daemon.rs) |  | ≤3.2 |
@@ -145,7 +145,7 @@ See [differences.md](differences.md) for a summary of notable behavioral differe
 | `--super` | — | ❌ | — | — |  | ≤3.2 |
 | `--temp-dir` | `-T` | ❌ | — | — |  | ≤3.2 |
 | `--timeout` | — | ✅ | ❌ | [tests/timeout.rs](../tests/timeout.rs) |  | ≤3.2 |
-| `--times` | `-t` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  | ≤3.2 |
+| `--times` | `-t` | ✅ | ✅ | [crates/engine/tests/attrs.rs](../crates/engine/tests/attrs.rs) |  | ≤3.2 |
 | `--trust-sender` | — | ❌ | — | — |  | ≤3.2 |
 | `--update` | `-u` | ❌ | — | — |  | ≤3.2 |
 | `--usermap` | — | ❌ | — | — |  | ≤3.2 |


### PR DESCRIPTION
## Summary
- support uid/gid mapping and nanosecond creation times in metadata
- map ownership when applying metadata in engine
- add regression test comparing metadata with stock rsync
- mark owner/group/time/crtime features as parity

## Testing
- `cargo test -p meta`
- `cargo test -p engine`


------
https://chatgpt.com/codex/tasks/task_e_68b2e0e52d5c83238b5a8a6beb255d46