### PR TITLE
Handle Unmatched data stats in block size tests

### DIFF
--- a/tests/block_size.rs
+++ b/tests/block_size.rs
@@ -7,7 +7,11 @@ use tempfile::tempdir;
 
 fn parse_literal(stats: &str) -> usize {
     for line in stats.lines() {
-        if let Some(rest) = line.trim().strip_prefix("Literal data: ") {
+        let line = line.trim();
+        if let Some(rest) = line
+            .strip_prefix("Literal data: ")
+            .or_else(|| line.strip_prefix("Unmatched data: "))
+        {
             let num_str = rest.split_whitespace().next().unwrap().replace(",", "");
             return num_str.parse().unwrap();
         }


### PR DESCRIPTION
## Summary
- Adjust block size test helper to accept `Unmatched data` in rsync stats

## Testing
- `cargo test --test block_size`
- `cargo test` *(fails: test remote_remote_via_ssh_paths has been running for over 60 seconds)*

------
https://chatgpt.com/codex/tasks/task_e_68b2e6401f2883238ecb703ae848bcbd