### PR TITLE
Use temp-dir for temporary files and document support

### DIFF
--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -711,10 +711,10 @@ impl Receiver {
         };
         let tmp_dest = if self.opts.inplace {
             dest.to_path_buf()
-        } else if self.opts.partial {
-            partial.clone()
         } else if let Some(dir) = &self.opts.temp_dir {
             dir.join(file_name).with_extension("tmp")
+        } else if self.opts.partial {
+            partial.clone()
         } else {
             dest.to_path_buf()
         };

--- a/docs/feature_matrix.md
+++ b/docs/feature_matrix.md
@@ -143,7 +143,7 @@ See [differences.md](differences.md) for a summary of notable behavioral differe
 | `--stop-at` | — | ❌ | — | — |  | ≤3.2 |
 | `--suffix` | — | ❌ | — | — |  | ≤3.2 |
 | `--super` | — | ❌ | — | — |  | ≤3.2 |
-| `--temp-dir` | `-T` | ❌ | — | — |  | ≤3.2 |
+| `--temp-dir` | `-T` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) | requires same filesystem for atomic rename | ≤3.2 |
 | `--timeout` | — | ✅ | ❌ | [tests/timeout.rs](../tests/timeout.rs) |  | ≤3.2 |
 | `--times` | `-t` | ✅ | ✅ | [crates/engine/tests/attrs.rs](../crates/engine/tests/attrs.rs) |  | ≤3.2 |
 | `--trust-sender` | — | ❌ | — | — |  | ≤3.2 |


### PR DESCRIPTION
## Summary
- honor `SyncOptions::temp_dir` by creating temp files there before renaming
- test CLI temp-dir behavior
- mark `--temp-dir` flag supported in feature matrix

## Testing
- `cargo test -p engine`
- `cargo test --test cli -- temp_files_created_in_temp_dir`


------
https://chatgpt.com/codex/tasks/task_e_68b2e39f69fc8323ad8cc83ced3e9dbe