### PR TITLE
Add CLI --version flag and docs

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -578,6 +578,10 @@ struct ProbeOpts {
 /// Execute the CLI using `std::env::args()`.
 pub fn run() -> Result<()> {
     let args: Vec<String> = env::args().collect();
+    if args.iter().any(|a| a == "--version" || a == "-V") {
+        println!("rsync-rs {}", env!("CARGO_PKG_VERSION"));
+        return Ok(());
+    }
     if args.iter().any(|a| a == "--daemon") {
         let opts = DaemonOpts::parse_from(&args);
         run_daemon(opts)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -45,6 +45,10 @@ rsync-rs [OPTIONS] <SRC> <DEST>
   ```sh
   rsync-rs -B 65536 ./src remote:/dst
   ```
+- Show version:
+  ```sh
+  rsync-rs --version
+  ```
 
 ### Trailing slash semantics
 

--- a/docs/feature_matrix.md
+++ b/docs/feature_matrix.md
@@ -150,7 +150,7 @@ See [differences.md](differences.md) for a summary of notable behavioral differe
 | `--update` | `-u` | ❌ | — | — |  | ≤3.2 |
 | `--usermap` | — | ❌ | — | — |  | ≤3.2 |
 | `--verbose` | `-v` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  | ≤3.2 |
-| `--version` | `-V` | ❌ | — | — |  | ≤3.2 |
+| `--version` | `-V` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  | ≤3.2 |
 | `--whole-file` | `-W` | ❌ | — | — |  | ≤3.2 |
 | `--write-batch` | — | ❌ | — | — |  | ≤3.2 |
 | `--write-devices` | — | ❌ | — | — |  | ≤3.2 |

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -11,6 +11,14 @@ use std::os::unix::fs::{FileTypeExt, MetadataExt, PermissionsExt};
 use tempfile::tempdir;
 
 #[test]
+fn prints_version() {
+    let mut cmd = Command::cargo_bin("rsync-rs").unwrap();
+    cmd.arg("--version");
+    let expected = format!("rsync-rs {}\n", env!("CARGO_PKG_VERSION"));
+    cmd.assert().success().stdout(expected).stderr("");
+}
+
+#[test]
 fn client_local_sync() {
     let dir = tempdir().unwrap();
     let src_dir = dir.path().join("src");


### PR DESCRIPTION
## Summary
- add `--version`/`-V` handling that prints the package version
- document and mark the flag as supported
- test that `--version` outputs `rsync-rs <version>`

## Testing
- `cargo test --test cli prints_version`

------
https://chatgpt.com/codex/tasks/task_e_68b2e3a587f4832384f6085f31ccb290