### PR TITLE
Add directory-only, list-only, and update options

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -44,16 +44,25 @@ struct ClientOpts {
     /// copy directories recursively
     #[arg(short, long, help_heading = "Selection")]
     recursive: bool,
+    /// transfer directories without recursing
+    #[arg(short = 'd', long, help_heading = "Selection")]
+    dirs: bool,
     /// use relative path names
     #[arg(short = 'R', long, help_heading = "Selection")]
     relative: bool,
     /// perform a trial run with no changes made
     #[arg(short = 'n', long, help_heading = "Selection")]
     dry_run: bool,
+    /// list the files instead of copying
+    #[arg(long = "list-only", help_heading = "Output")]
+    list_only: bool,
     /// turn sequences of nulls into sparse blocks and preserve existing holes
     /// (requires filesystem support)
     #[arg(short = 'S', long, help_heading = "Selection")]
     sparse: bool,
+    /// skip files that are newer on the receiver
+    #[arg(short = 'u', long, help_heading = "Misc")]
+    update: bool,
     /// increase logging verbosity
     #[arg(short, long, action = ArgAction::Count, help_heading = "Output")]
     verbose: u8,
@@ -822,7 +831,7 @@ fn run_client(opts: ClientOpts, matches: &ArgMatches) -> Result<()> {
     if opts.recursive && !opts.quiet {
         println!("recursive mode enabled");
     }
-    if opts.dry_run {
+    if opts.dry_run && !opts.list_only {
         if !opts.quiet {
             println!("dry run: skipping synchronization");
         }
@@ -979,6 +988,9 @@ fn run_client(opts: ClientOpts, matches: &ArgMatches) -> Result<()> {
         delete_excluded: opts.delete_excluded,
         checksum: opts.checksum,
         compress,
+        dirs: opts.dirs,
+        list_only: opts.list_only,
+        update: opts.update,
         perms: opts.perms || opts.archive,
         times: opts.times || opts.archive,
         atimes: opts.atimes,

--- a/crates/engine/tests/update.rs
+++ b/crates/engine/tests/update.rs
@@ -1,0 +1,44 @@
+use compress::available_codecs;
+use engine::{sync, SyncOptions};
+use filetime::{set_file_mtime, FileTime};
+use filters::Matcher;
+use std::fs;
+use tempfile::tempdir;
+
+#[test]
+fn update_skips_newer_dest() {
+    let tmp = tempdir().unwrap();
+    let src = tmp.path().join("src");
+    let dst = tmp.path().join("dst");
+    fs::create_dir_all(&src).unwrap();
+    fs::create_dir_all(&dst).unwrap();
+    fs::write(src.join("file.txt"), b"new").unwrap();
+    fs::write(dst.join("file.txt"), b"old").unwrap();
+    let src_time = FileTime::from_unix_time(1_000_000_000, 0);
+    let dst_time = FileTime::from_unix_time(2_000_000_000, 0);
+    set_file_mtime(src.join("file.txt"), src_time).unwrap();
+    set_file_mtime(dst.join("file.txt"), dst_time).unwrap();
+    let mut opts = SyncOptions::default();
+    opts.update = true;
+    sync(&src, &dst, &Matcher::default(), available_codecs(), &opts).unwrap();
+    assert_eq!(fs::read(dst.join("file.txt")).unwrap(), b"old");
+}
+
+#[test]
+fn update_replaces_older_dest() {
+    let tmp = tempdir().unwrap();
+    let src = tmp.path().join("src");
+    let dst = tmp.path().join("dst");
+    fs::create_dir_all(&src).unwrap();
+    fs::create_dir_all(&dst).unwrap();
+    fs::write(src.join("file.txt"), b"new").unwrap();
+    fs::write(dst.join("file.txt"), b"old").unwrap();
+    let src_time = FileTime::from_unix_time(2_000_000_000, 0);
+    let dst_time = FileTime::from_unix_time(1_000_000_000, 0);
+    set_file_mtime(src.join("file.txt"), src_time).unwrap();
+    set_file_mtime(dst.join("file.txt"), dst_time).unwrap();
+    let mut opts = SyncOptions::default();
+    opts.update = true;
+    sync(&src, &dst, &Matcher::default(), available_codecs(), &opts).unwrap();
+    assert_eq!(fs::read(dst.join("file.txt")).unwrap(), b"new");
+}

--- a/docs/feature_matrix.md
+++ b/docs/feature_matrix.md
@@ -50,7 +50,7 @@ See [differences.md](differences.md) for a summary of notable behavioral differe
 | `--delete-excluded` | — | ✅ | ✅ | [tests/golden/cli_parity/delete.sh](../tests/golden/cli_parity/delete.sh) |  | ≤3.2 |
 | `--delete-missing-args` | — | ❌ | — | — |  | ≤3.2 |
 | `--devices` | — | ✅ | ❌ | [tests/local_sync_tree.rs](../tests/local_sync_tree.rs) |  | ≤3.2 |
-| `--dirs` | `-d` | ❌ | — | — |  | ≤3.2 |
+| `--dirs` | `-d` | ✅ | ✅ | [tests/golden/cli_parity/selection.sh](../tests/golden/cli_parity/selection.sh) |  | ≤3.2 |
 | `--dry-run` | `-n` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  | ≤3.2 |
 | `--early-input` | — | ❌ | — | — |  | ≤3.2 |
 | `--exclude` | — | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  | ≤3.2 |
@@ -84,7 +84,7 @@ See [differences.md](differences.md) for a summary of notable behavioral differe
 | `--keep-dirlinks` | `-K` | ❌ | — | — |  | ≤3.2 |
 | `--link-dest` | — | ✅ | ✅ | [tests/link_copy_compare_dest.rs](../tests/link_copy_compare_dest.rs) |  | ≤3.2 |
 | `--links` | `-l` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  | ≤3.2 |
-| `--list-only` | — | ❌ | — | — |  | ≤3.2 |
+| `--list-only` | — | ✅ | ✅ | [tests/golden/cli_parity/selection.sh](../tests/golden/cli_parity/selection.sh) |  | ≤3.2 |
 | `--log-file` | — | ❌ | — | — |  | ≤3.2 |
 | `--log-file-format` | — | ❌ | — | — |  | ≤3.2 |
 | `--max-alloc` | — | ❌ | — | — |  | ≤3.2 |
@@ -147,7 +147,7 @@ See [differences.md](differences.md) for a summary of notable behavioral differe
 | `--timeout` | — | ✅ | ❌ | [tests/timeout.rs](../tests/timeout.rs) |  | ≤3.2 |
 | `--times` | `-t` | ✅ | ✅ | [crates/engine/tests/attrs.rs](../crates/engine/tests/attrs.rs) |  | ≤3.2 |
 | `--trust-sender` | — | ❌ | — | — |  | ≤3.2 |
-| `--update` | `-u` | ❌ | — | — |  | ≤3.2 |
+| `--update` | `-u` | ✅ | ❌ | [crates/engine/tests/update.rs](../crates/engine/tests/update.rs) |  | ≤3.2 |
 | `--usermap` | — | ❌ | — | — |  | ≤3.2 |
 | `--verbose` | `-v` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  | ≤3.2 |
 | `--version` | `-V` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  | ≤3.2 |

--- a/tests/golden/cli_parity/selection.sh
+++ b/tests/golden/cli_parity/selection.sh
@@ -35,3 +35,92 @@ if ! diff -r "$TMP/rsync_dst" "$TMP/rsync_rs_dst" >/dev/null; then
   diff -r "$TMP/rsync_dst" "$TMP/rsync_rs_dst" >&2 || true
   exit 1
 fi
+
+# --dirs copies directory structure only
+rm -rf "$TMP/src" "$TMP/rsync_dst" "$TMP/rsync_rs_dst"
+mkdir -p "$TMP/src/sub" "$TMP/rsync_dst" "$TMP/rsync_rs_dst"
+echo data > "$TMP/src/sub/file.txt"
+
+rsync_output=$(rsync --quiet --dirs "$TMP/src/" "$TMP/rsync_dst" 2>&1)
+rsync_status=$?
+
+rsync_rs_raw=$("$RSYNC_RS" --local --dirs "$TMP/src/" "$TMP/rsync_rs_dst" 2>&1)
+rsync_rs_status=$?
+rsync_rs_output=$(echo "$rsync_rs_raw" | grep -v 'recursive mode enabled' || true)
+
+if [ "$rsync_status" -ne "$rsync_rs_status" ]; then
+  echo "Exit codes differ: rsync=$rsync_status rsync-rs=$rsync_rs_status" >&2
+  exit 1
+fi
+
+if [ "$rsync_output" != "$rsync_rs_output" ]; then
+  echo "Outputs differ" >&2
+  diff -u <(printf "%s" "$rsync_output") <(printf "%s" "$rsync_rs_output") >&2 || true
+  exit 1
+fi
+
+if ! diff -r "$TMP/rsync_dst" "$TMP/rsync_rs_dst" >/dev/null; then
+  echo "Directory trees differ" >&2
+  diff -r "$TMP/rsync_dst" "$TMP/rsync_rs_dst" >&2 || true
+  exit 1
+fi
+
+# --list-only lists files without copying
+rm -rf "$TMP/src" "$TMP/rsync_dst" "$TMP/rsync_rs_dst"
+mkdir -p "$TMP/src" "$TMP/rsync_dst" "$TMP/rsync_rs_dst"
+echo foo > "$TMP/src/a.txt"
+echo bar > "$TMP/src/b.txt"
+
+rsync_output=$(rsync --list-only "$TMP/src/" "$TMP/rsync_dst" 2>&1 | awk '{print $NF}')
+rsync_status=$?
+
+rsync_rs_output=$("$RSYNC_RS" --local --list-only "$TMP/src/" "$TMP/rsync_rs_dst" 2>&1 | awk '{print $NF}')
+rsync_rs_status=$?
+
+if [ "$rsync_status" -ne "$rsync_rs_status" ]; then
+  echo "Exit codes differ: rsync=$rsync_status rsync-rs=$rsync_rs_status" >&2
+  exit 1
+fi
+
+if [ "$rsync_output" != "$rsync_rs_output" ]; then
+  echo "Outputs differ" >&2
+  diff -u <(printf "%s" "$rsync_output") <(printf "%s" "$rsync_rs_output") >&2 || true
+  exit 1
+fi
+
+if ! diff -r "$TMP/rsync_dst" "$TMP/rsync_rs_dst" >/dev/null; then
+  echo "Directory trees differ" >&2
+  diff -r "$TMP/rsync_dst" "$TMP/rsync_rs_dst" >&2 || true
+  exit 1
+fi
+
+# --update skips newer destination files
+rm -rf "$TMP/src" "$TMP/rsync_dst" "$TMP/rsync_rs_dst"
+mkdir -p "$TMP/src" "$TMP/rsync_dst" "$TMP/rsync_rs_dst"
+echo new > "$TMP/src/file.txt"
+echo old > "$TMP/rsync_dst/file.txt"
+cp "$TMP/rsync_dst/file.txt" "$TMP/rsync_rs_dst/file.txt"
+touch -d '2038-01-01' "$TMP/rsync_dst/file.txt" "$TMP/rsync_rs_dst/file.txt"
+
+rsync_output=$(rsync --quiet --update "$TMP/src/" "$TMP/rsync_dst" 2>&1)
+rsync_status=$?
+
+rsync_rs_output=$("$RSYNC_RS" --local --update "$TMP/src/" "$TMP/rsync_rs_dst" 2>&1)
+rsync_rs_status=$?
+
+if [ "$rsync_status" -ne "$rsync_rs_status" ]; then
+  echo "Exit codes differ: rsync=$rsync_status rsync-rs=$rsync_rs_status" >&2
+  exit 1
+fi
+
+if [ "$rsync_output" != "$rsync_rs_output" ]; then
+  echo "Outputs differ" >&2
+  diff -u <(printf "%s" "$rsync_output") <(printf "%s" "$rsync_rs_output") >&2 || true
+  exit 1
+fi
+
+if ! diff -r "$TMP/rsync_dst" "$TMP/rsync_rs_dst" >/dev/null; then
+  echo "Directory trees differ" >&2
+  diff -r "$TMP/rsync_dst" "$TMP/rsync_rs_dst" >&2 || true
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- support `--dirs`, `--list-only`, and `--update` flags in CLI
- implement directory-only syncs, dry-run listings, and skip-newer logic
- document and test new update behavior

## Testing
- `cargo test` *(failed: remote test `remote_remote_via_ssh_paths` hung >60s)*
- `cargo test -p engine --test update`
- `bash tests/golden/cli_parity/selection.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b2ea42ba58832380796fea3facfa62