### PR TITLE
Add path headers and remove inline comments

### DIFF
--- a/bin/rsync-rs/src/main.rs
+++ b/bin/rsync-rs/src/main.rs
@@ -1,3 +1,4 @@
+// bin/rsync-rs/src/main.rs
 use engine::Result;
 
 fn main() -> Result<()> {

--- a/crates/checksums/src/lib.rs
+++ b/crates/checksums/src/lib.rs
@@ -1,9 +1,9 @@
-use md5::{Digest, Md5};
-use sha1::Sha1;
+// crates/checksums/src/lib.rs
 #[cfg(feature = "blake3")]
 use blake3::Hasher as Blake3;
+use md5::{Digest, Md5};
+use sha1::Sha1;
 
-/// Algorithms that can be used for the strong digest.
 #[derive(Clone, Copy, Debug)]
 pub enum StrongHash {
     Md5,
@@ -12,13 +12,11 @@ pub enum StrongHash {
     Blake3,
 }
 
-/// Configuration for checksum computation.
 #[derive(Clone, Debug)]
 pub struct ChecksumConfig {
     strong: StrongHash,
 }
 
-/// Builder for [`ChecksumConfig`].
 #[derive(Clone, Debug)]
 pub struct ChecksumConfigBuilder {
     strong: StrongHash,
@@ -33,18 +31,15 @@ impl Default for ChecksumConfigBuilder {
 }
 
 impl ChecksumConfigBuilder {
-    /// Create a new builder with default settings (MD5 strong digest).
     pub fn new() -> Self {
         Self::default()
     }
 
-    /// Choose the strong hash algorithm to use when building the config.
     pub fn strong(mut self, alg: StrongHash) -> Self {
         self.strong = alg;
         self
     }
 
-    /// Finalize the builder and produce a [`ChecksumConfig`].
     pub fn build(self) -> ChecksumConfig {
         ChecksumConfig {
             strong: self.strong,
@@ -52,7 +47,6 @@ impl ChecksumConfigBuilder {
     }
 }
 
-/// Result of computing both the rolling checksum and a strong digest.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Checksums {
     pub weak: u32,
@@ -60,7 +54,6 @@ pub struct Checksums {
 }
 
 impl ChecksumConfig {
-    /// Compute both the rolling checksum and strong digest for `data`.
     pub fn checksum(&self, data: &[u8]) -> Checksums {
         Checksums {
             weak: rolling_checksum(data),
@@ -69,7 +62,6 @@ impl ChecksumConfig {
     }
 }
 
-/// Compute a strong digest of the data using the requested algorithm.
 pub fn strong_digest(data: &[u8], alg: StrongHash) -> Vec<u8> {
     match alg {
         StrongHash::Md5 => {
@@ -91,7 +83,6 @@ pub fn strong_digest(data: &[u8], alg: StrongHash) -> Vec<u8> {
     }
 }
 
-/// Compute the rsync rolling checksum for a block of data.
 pub fn rolling_checksum(data: &[u8]) -> u32 {
     let mut s1: u32 = 0;
     let mut s2: u32 = 0;
@@ -103,7 +94,6 @@ pub fn rolling_checksum(data: &[u8]) -> u32 {
     (s1 & 0xffff) | (s2 << 16)
 }
 
-/// Rolling checksum state allowing incremental updates.
 #[derive(Debug, Clone)]
 pub struct Rolling {
     len: usize,
@@ -138,7 +128,6 @@ impl Rolling {
     }
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -146,7 +135,7 @@ mod tests {
     #[test]
     fn rolling_known() {
         let sum = rolling_checksum(b"hello world");
-        assert_eq!(sum, 436208732); // verified against rsync implementation
+        assert_eq!(sum, 436208732);
     }
 
     #[test]

--- a/crates/checksums/tests/golden.rs
+++ b/crates/checksums/tests/golden.rs
@@ -1,4 +1,5 @@
-use checksums::{rolling_checksum, Rolling, ChecksumConfigBuilder, StrongHash};
+// crates/checksums/tests/golden.rs
+use checksums::{rolling_checksum, ChecksumConfigBuilder, Rolling, StrongHash};
 
 #[test]
 fn rolling_golden_windows() {
@@ -17,10 +18,9 @@ fn rolling_golden_windows() {
     ];
 
     for (i, &exp) in expected.iter().enumerate() {
-        assert_eq!(rolling_checksum(&data[i..i+win]), exp);
+        assert_eq!(rolling_checksum(&data[i..i + win]), exp);
     }
 
-    // Cross-check using incremental rolling state
     let mut r = Rolling::new(&data[0..win]);
     for (i, &exp) in expected.iter().enumerate() {
         assert_eq!(r.digest(), exp);
@@ -33,12 +33,17 @@ fn rolling_golden_windows() {
 #[test]
 fn builder_strong_digests() {
     let cfg_md5 = ChecksumConfigBuilder::new().strong(StrongHash::Md5).build();
-    let cfg_sha1 = ChecksumConfigBuilder::new().strong(StrongHash::Sha1).build();
+    let cfg_sha1 = ChecksumConfigBuilder::new()
+        .strong(StrongHash::Sha1)
+        .build();
     let data = b"hello world";
 
     let cs_md5 = cfg_md5.checksum(data);
     assert_eq!(cs_md5.weak, rolling_checksum(data));
-    assert_eq!(hex::encode(cs_md5.strong), "5eb63bbbe01eeed093cb22bb8f5acdc3");
+    assert_eq!(
+        hex::encode(cs_md5.strong),
+        "5eb63bbbe01eeed093cb22bb8f5acdc3"
+    );
 
     let cs_sha1 = cfg_sha1.checksum(data);
     assert_eq!(cs_sha1.weak, rolling_checksum(data));
@@ -49,7 +54,9 @@ fn builder_strong_digests() {
 
     #[cfg(feature = "blake3")]
     {
-        let cfg_blake3 = ChecksumConfigBuilder::new().strong(StrongHash::Blake3).build();
+        let cfg_blake3 = ChecksumConfigBuilder::new()
+            .strong(StrongHash::Blake3)
+            .build();
         let cs_blake3 = cfg_blake3.checksum(data);
         assert_eq!(cs_blake3.weak, rolling_checksum(data));
         assert_eq!(

--- a/crates/cli/tests/golden.rs
+++ b/crates/cli/tests/golden.rs
@@ -1,3 +1,4 @@
+// crates/cli/tests/golden.rs
 use cli::parse_chmod_spec;
 
 #[test]

--- a/crates/compress/tests/codecs.rs
+++ b/crates/compress/tests/codecs.rs
@@ -1,6 +1,7 @@
-use compress::{negotiate_codec, Codec, Compressor, Decompressor, Zlib, Zstd};
+// crates/compress/tests/codecs.rs
 #[cfg(feature = "lz4")]
 use compress::Lz4;
+use compress::{negotiate_codec, Codec, Compressor, Decompressor, Zlib, Zstd};
 
 const DATA: &[u8] = b"The quick brown fox jumps over the lazy dog";
 

--- a/crates/engine/benches/large_files.rs
+++ b/crates/engine/benches/large_files.rs
@@ -1,3 +1,4 @@
+// crates/engine/benches/large_files.rs
 use checksums::ChecksumConfigBuilder;
 use criterion::{criterion_group, criterion_main, Criterion};
 use engine::compute_delta;
@@ -7,7 +8,7 @@ fn bench_large_delta(c: &mut Criterion) {
     let cfg = ChecksumConfigBuilder::new().build();
     let block_size = 1024;
     let window = 64;
-    let data = vec![0u8; block_size * 1024]; // 1 MiB
+    let data = vec![0u8; block_size * 1024];
     c.bench_function("compute_delta_large_file", |b| {
         b.iter(|| {
             let mut basis = Cursor::new(data.clone());
@@ -61,7 +62,7 @@ fn bench_streaming_delta(c: &mut Criterion) {
     let cfg = ChecksumConfigBuilder::new().build();
     let block_size = 1024;
     let window = 64;
-    let len = 2 * 1024 * 1024 * 1024u64; // 2 GiB
+    let len = 2 * 1024 * 1024 * 1024u64;
     c.bench_function("stream_delta_2gb_zero", |b| {
         b.iter(|| {
             let mut basis = ZeroReader::new(len);

--- a/crates/engine/tests/attrs.rs
+++ b/crates/engine/tests/attrs.rs
@@ -1,3 +1,4 @@
+// crates/engine/tests/attrs.rs
 #![cfg(unix)]
 
 use std::fs::{self, File};
@@ -110,7 +111,7 @@ fn crtimes_roundtrip() {
     let src_meta = fs::metadata(&file).unwrap();
     let src_crtime = match src_meta.created() {
         Ok(t) => t,
-        Err(_) => return, // platform does not support creation time
+        Err(_) => return,
     };
 
     std::thread::sleep(Duration::from_secs(1));

--- a/crates/engine/tests/backup.rs
+++ b/crates/engine/tests/backup.rs
@@ -1,3 +1,4 @@
+// crates/engine/tests/backup.rs
 use std::fs;
 
 use compress::available_codecs;

--- a/crates/engine/tests/checksum.rs
+++ b/crates/engine/tests/checksum.rs
@@ -1,3 +1,4 @@
+// crates/engine/tests/checksum.rs
 use std::fs;
 
 use compress::available_codecs;

--- a/crates/engine/tests/compress.rs
+++ b/crates/engine/tests/compress.rs
@@ -1,3 +1,4 @@
+// crates/engine/tests/compress.rs
 use std::fs;
 
 use compress::Codec;
@@ -17,7 +18,10 @@ fn zlib_roundtrip() {
         &dst,
         &Matcher::default(),
         &[Codec::Zlib],
-        &SyncOptions { compress: true, ..Default::default() },
+        &SyncOptions {
+            compress: true,
+            ..Default::default()
+        },
     )
     .unwrap();
     assert_eq!(fs::read(dst.join("file.txt")).unwrap(), b"hello world");
@@ -35,7 +39,10 @@ fn zstd_roundtrip() {
         &dst,
         &Matcher::default(),
         &[Codec::Zstd],
-        &SyncOptions { compress: true, ..Default::default() },
+        &SyncOptions {
+            compress: true,
+            ..Default::default()
+        },
     )
     .unwrap();
     assert_eq!(fs::read(dst.join("file.txt")).unwrap(), b"hello world");
@@ -54,7 +61,10 @@ fn lz4_roundtrip() {
         &dst,
         &Matcher::default(),
         &[Codec::Lz4],
-        &SyncOptions { compress: true, ..Default::default() },
+        &SyncOptions {
+            compress: true,
+            ..Default::default()
+        },
     )
     .unwrap();
     assert_eq!(fs::read(dst.join("file.txt")).unwrap(), b"hello world");
@@ -62,9 +72,19 @@ fn lz4_roundtrip() {
 
 #[test]
 fn codec_selection_prefers_zstd() {
-    let opts = SyncOptions { compress: true, ..Default::default() };
-    assert_eq!(select_codec(&[Codec::Zlib, Codec::Zstd], &opts), Some(Codec::Zstd));
+    let opts = SyncOptions {
+        compress: true,
+        ..Default::default()
+    };
+    assert_eq!(
+        select_codec(&[Codec::Zlib, Codec::Zstd], &opts),
+        Some(Codec::Zstd)
+    );
     assert_eq!(select_codec(&[Codec::Zlib], &opts), Some(Codec::Zlib));
-    let opts = SyncOptions { compress: true, compress_level: Some(0), ..Default::default() };
+    let opts = SyncOptions {
+        compress: true,
+        compress_level: Some(0),
+        ..Default::default()
+    };
     assert_eq!(select_codec(&[Codec::Zstd], &opts), None);
 }

--- a/crates/engine/tests/filter.rs
+++ b/crates/engine/tests/filter.rs
@@ -1,3 +1,4 @@
+// crates/engine/tests/filter.rs
 use compress::available_codecs;
 use engine::{sync, SyncOptions};
 use filters::{parse, Matcher};

--- a/crates/engine/tests/resume.rs
+++ b/crates/engine/tests/resume.rs
@@ -1,6 +1,7 @@
+// crates/engine/tests/resume.rs
+use checksums::ChecksumConfigBuilder;
 use compress::available_codecs;
 use engine::{compute_delta, sync, Op, SyncOptions};
-use checksums::ChecksumConfigBuilder;
 use filters::Matcher;
 use std::fs::{self, File};
 use tempfile::tempdir;
@@ -22,7 +23,6 @@ fn resume_from_partial_file() {
     src_data.extend_from_slice(&block3);
     fs::write(src.join("file.bin"), &src_data).unwrap();
 
-    // create partial file with first block correct, second block corrupted
     let mut partial_data = Vec::new();
     partial_data.extend_from_slice(&block);
     partial_data.extend_from_slice(&vec![0u8; 1024]);
@@ -45,7 +45,7 @@ fn resume_large_file_minimal_network_io() {
     fs::create_dir_all(&dst).unwrap();
 
     let block_size = 1024;
-    let total_blocks = 256; // 256 KiB file
+    let total_blocks = 256;
     let total_len = block_size * total_blocks;
     let partial_len = total_len / 2;
     let mut data = Vec::with_capacity(total_len);
@@ -55,7 +55,6 @@ fn resume_large_file_minimal_network_io() {
 
     fs::write(dst.join("big.bin.partial"), &data[..partial_len]).unwrap();
 
-    // Estimate the amount of data that should be resent
     let cfg = ChecksumConfigBuilder::new().build();
     let mut basis = File::open(dst.join("big.bin.partial")).unwrap();
     let mut target = File::open(src.join("big.bin")).unwrap();

--- a/crates/engine/tests/streaming.rs
+++ b/crates/engine/tests/streaming.rs
@@ -1,3 +1,4 @@
+// crates/engine/tests/streaming.rs
 use compress::available_codecs;
 use engine::{sync, SyncOptions};
 use filters::Matcher;

--- a/crates/engine/tests/update.rs
+++ b/crates/engine/tests/update.rs
@@ -1,3 +1,4 @@
+// crates/engine/tests/update.rs
 use compress::available_codecs;
 use engine::{sync, SyncOptions};
 use filetime::{set_file_mtime, FileTime};

--- a/crates/filters/tests/anchored_dir_merge.rs
+++ b/crates/filters/tests/anchored_dir_merge.rs
@@ -1,3 +1,4 @@
+// crates/filters/tests/anchored_dir_merge.rs
 use filters::{parse, Matcher};
 use std::collections::HashSet;
 use std::fs;
@@ -8,9 +9,7 @@ fn anchored_dir_merge_uses_root_file() {
     let tmp = tempdir().unwrap();
     let root = tmp.path();
 
-    // Root filter excludes "secret".
     fs::write(root.join(".rsync-filter"), "- secret\n").unwrap();
-    // Subdirectory filter attempts to include "secret" but should be ignored.
     let sub = root.join("sub");
     fs::create_dir_all(&sub).unwrap();
     fs::write(sub.join(".rsync-filter"), "+ secret\n").unwrap();
@@ -19,8 +18,6 @@ fn anchored_dir_merge_uses_root_file() {
     let rules = parse("dir-merge /.rsync-filter\n", &mut v, 0).unwrap();
     let matcher = Matcher::new(rules).with_root(root);
 
-    // The anchored dir-merge directive should always load the filter from the
-    // transfer root, so the subdirectory's attempt to override it is ignored.
     assert!(!matcher.is_included("secret").unwrap());
     assert!(!matcher.is_included("sub/secret").unwrap());
 }

--- a/crates/filters/tests/anchored_wildcards.rs
+++ b/crates/filters/tests/anchored_wildcards.rs
@@ -1,3 +1,4 @@
+// crates/filters/tests/anchored_wildcards.rs
 use filters::{parse, Matcher};
 use std::collections::HashSet;
 

--- a/crates/filters/tests/comments.rs
+++ b/crates/filters/tests/comments.rs
@@ -1,3 +1,4 @@
+// crates/filters/tests/comments.rs
 use filters::{parse, Matcher};
 use std::collections::HashSet;
 
@@ -8,7 +9,6 @@ fn p(input: &str) -> Vec<filters::Rule> {
 
 #[test]
 fn comments_and_blank_lines_are_ignored() {
-    // Leading comment and blank line should be ignored by the parser
     let rules = p("# initial comment\n\n+ keep.log\n- *.log\n");
     let matcher = Matcher::new(rules);
 

--- a/crates/filters/tests/cvs_rules.rs
+++ b/crates/filters/tests/cvs_rules.rs
@@ -1,3 +1,4 @@
+// crates/filters/tests/cvs_rules.rs
 use filters::{parse, Matcher};
 use std::collections::HashSet;
 

--- a/crates/filters/tests/files_from.rs
+++ b/crates/filters/tests/files_from.rs
@@ -1,3 +1,4 @@
+// crates/filters/tests/files_from.rs
 use filters::parse;
 use filters::Matcher;
 use std::collections::HashSet;

--- a/crates/filters/tests/include_exclude.rs
+++ b/crates/filters/tests/include_exclude.rs
@@ -1,3 +1,4 @@
+// crates/filters/tests/include_exclude.rs
 use filters::{parse, Matcher};
 use proptest::prelude::*;
 use std::collections::HashSet;

--- a/crates/filters/tests/include_merge.rs
+++ b/crates/filters/tests/include_merge.rs
@@ -1,3 +1,4 @@
+// crates/filters/tests/include_merge.rs
 use filters::{parse, Matcher};
 use std::collections::HashSet;
 use std::fs;
@@ -8,7 +9,6 @@ fn nested_include_merge_applies() {
     let tmp = tempdir().unwrap();
     let root = tmp.path();
 
-    // Create nested filter files
     let rules3 = root.join("rules3");
     fs::write(&rules3, "- tmp/\n").unwrap();
 
@@ -22,7 +22,6 @@ fn nested_include_merge_applies() {
     let rules1 = root.join("rules1");
     fs::write(&rules1, format!(":include-merge {}\n", rules2.display())).unwrap();
 
-    // Source tree
     fs::create_dir_all(root.join("src/dir")).unwrap();
     fs::create_dir_all(root.join("src/tmp")).unwrap();
     fs::write(root.join("src/root.txt"), "root").unwrap();

--- a/crates/filters/tests/malformed.rs
+++ b/crates/filters/tests/malformed.rs
@@ -1,3 +1,4 @@
+// crates/filters/tests/malformed.rs
 use filters::{parse, Matcher};
 use std::collections::HashSet;
 use std::fs;

--- a/crates/filters/tests/merge.rs
+++ b/crates/filters/tests/merge.rs
@@ -1,3 +1,4 @@
+// crates/filters/tests/merge.rs
 use filters::{parse, Matcher};
 use proptest::prelude::*;
 use std::collections::HashSet;
@@ -15,7 +16,6 @@ fn rsync_filter_merge() {
     assert!(matcher.is_included("notes.txt").unwrap());
     assert!(!matcher.is_included("junk.tmp").unwrap());
 
-    // Merge rules from a subdirectory `.rsync-filter` file
     let sub_rules = p("- secret\n");
     matcher.merge(sub_rules);
 

--- a/crates/filters/tests/merge_order.rs
+++ b/crates/filters/tests/merge_order.rs
@@ -1,3 +1,4 @@
+// crates/filters/tests/merge_order.rs
 use filters::{parse, Matcher};
 use std::collections::HashSet;
 use std::fs;
@@ -8,20 +9,16 @@ fn rsync_filter_merge_order_and_wildcards() {
     let tmp = tempdir().unwrap();
     let root = tmp.path();
 
-    // Root excludes all log files.
     fs::write(root.join(".rsync-filter"), "- *.log\n").unwrap();
 
-    // Subdirectory re-includes log files.
     let sub = root.join("sub");
     fs::create_dir_all(&sub).unwrap();
     fs::write(sub.join(".rsync-filter"), "+ *.log\n").unwrap();
 
-    // Nested directory excludes a specific log again.
     let nested = sub.join("nested");
     fs::create_dir_all(&nested).unwrap();
     fs::write(nested.join(".rsync-filter"), "- debug.log\n").unwrap();
 
-    // Global rules mirror recorded rsync behaviour with -F.
     let mut v = HashSet::new();
     let global = parse(
         ": /.rsync-filter\n- .rsync-filter\n+ *.log\n- *\n",
@@ -31,15 +28,10 @@ fn rsync_filter_merge_order_and_wildcards() {
     .unwrap();
     let matcher = Matcher::new(global).with_root(root);
 
-    // Root rule overrides global include.
     assert!(!matcher.is_included("a.log").unwrap());
-    // Sub rule overrides root exclude.
     assert!(matcher.is_included("sub/b.log").unwrap());
-    // Nested rule overrides sub include.
     assert!(!matcher.is_included("sub/nested/debug.log").unwrap());
-    // Sub wildcard applies to deeper paths.
     assert!(matcher.is_included("sub/nested/trace.log").unwrap());
-    // Global catch-all excludes non-log files.
     assert!(!matcher.is_included("sub/nested/file.txt").unwrap());
 }
 

--- a/crates/filters/tests/nested_merge.rs
+++ b/crates/filters/tests/nested_merge.rs
@@ -1,3 +1,4 @@
+// crates/filters/tests/nested_merge.rs
 use filters::{parse, Matcher};
 use proptest::prelude::*;
 use std::collections::HashSet;

--- a/crates/filters/tests/recursive_filters.rs
+++ b/crates/filters/tests/recursive_filters.rs
@@ -1,3 +1,4 @@
+// crates/filters/tests/recursive_filters.rs
 use filters::{parse, Matcher};
 use std::collections::HashSet;
 use std::fs;

--- a/crates/filters/tests/rsync_filter_files.rs
+++ b/crates/filters/tests/rsync_filter_files.rs
@@ -1,3 +1,4 @@
+// crates/filters/tests/rsync_filter_files.rs
 use filters::{parse, Matcher};
 use proptest::prelude::*;
 use std::collections::HashSet;

--- a/crates/filters/tests/rsync_parity.rs
+++ b/crates/filters/tests/rsync_parity.rs
@@ -1,3 +1,4 @@
+// crates/filters/tests/rsync_parity.rs
 use filters::{parse, Matcher};
 use std::collections::HashSet;
 use std::fs;

--- a/crates/filters/tests/rsync_property.rs
+++ b/crates/filters/tests/rsync_property.rs
@@ -1,3 +1,4 @@
+// crates/filters/tests/rsync_property.rs
 use filters::{parse, Matcher};
 use proptest::prelude::*;
 use std::collections::HashSet;
@@ -14,8 +15,6 @@ fn rule_strategy() -> impl Strategy<Value = String> {
         Just("P keep.tmp".to_string()),
         Just("-! */".to_string()),
         Just("+! */".to_string()),
-        // Clear rule is omitted from random generation to keep precedence
-        // behaviour focused on pattern modifiers.
     ]
 }
 

--- a/crates/filters/tests/rule_prefixes.rs
+++ b/crates/filters/tests/rule_prefixes.rs
@@ -1,3 +1,4 @@
+// crates/filters/tests/rule_prefixes.rs
 use filters::{parse, Matcher};
 use proptest::prelude::*;
 use std::collections::HashSet;

--- a/crates/meta/tests/roundtrip.rs
+++ b/crates/meta/tests/roundtrip.rs
@@ -1,3 +1,4 @@
+// crates/meta/tests/roundtrip.rs
 use std::fs;
 use std::os::unix::fs::PermissionsExt;
 
@@ -16,7 +17,6 @@ fn roundtrip_full_metadata() -> std::io::Result<()> {
     fs::write(&src, b"hello")?;
     fs::write(&dst, b"world")?;
 
-    // Customize source metadata
     let mode = 0o741;
     let mtime = FileTime::from_unix_time(1_000_000, 123_456_789);
     let atime = FileTime::from_system_time(SystemTime::now());
@@ -28,7 +28,6 @@ fn roundtrip_full_metadata() -> std::io::Result<()> {
     )?;
     filetime::set_file_times(&src, atime, mtime)?;
 
-    // Make destination different
     nix::sys::stat::fchmodat(
         None,
         &dst,
@@ -75,7 +74,6 @@ fn default_skips_owner_group_perms() -> std::io::Result<()> {
     fs::write(&src, b"hello")?;
     fs::write(&dst, b"world")?;
 
-    // Set differing metadata
     nix::sys::stat::fchmodat(
         None,
         &src,
@@ -142,7 +140,6 @@ fn roundtrip_acl() -> std::io::Result<()> {
     fs::write(&src, b"hello")?;
     fs::write(&dst, b"world")?;
 
-    // Add extra ACL entry to source
     let mut acl = PosixACL::read_acl(&src).map_err(|e| {
         if let Some(ioe) = e.as_io_error() {
             if let Some(code) = ioe.raw_os_error() {

--- a/crates/protocol/src/mux.rs
+++ b/crates/protocol/src/mux.rs
@@ -1,3 +1,4 @@
+// crates/protocol/src/mux.rs
 use indexmap::IndexMap;
 use std::sync::mpsc::{self, Receiver, Sender, TryRecvError};
 use std::time::{Duration, Instant};
@@ -10,13 +11,6 @@ struct Channel {
     last_sent: Instant,
 }
 
-/// Multiplex messages from multiple channels into a single frame stream.
-///
-/// Each registered channel is associated with a [`Sender`] returned by
-/// [`Mux::register_channel`]. Messages sent through these senders are converted
-/// into [`Frame`]s when [`Mux::poll`] is invoked. If a channel is idle for
-/// longer than the configured keepalive interval a [`Message::KeepAlive`] frame
-/// is emitted.
 pub struct Mux {
     keepalive: Duration,
     channels: IndexMap<u16, Channel>,
@@ -24,7 +18,6 @@ pub struct Mux {
 }
 
 impl Mux {
-    /// Create a new multiplexer with the specified keepalive interval.
     pub fn new(keepalive: Duration) -> Self {
         Mux {
             keepalive,
@@ -33,7 +26,6 @@ impl Mux {
         }
     }
 
-    /// Register a new channel and return a [`Sender`] for queuing messages.
     pub fn register_channel(&mut self, id: u16) -> Sender<Message> {
         let (tx, rx) = mpsc::channel();
         let ch = Channel {
@@ -45,7 +37,6 @@ impl Mux {
         tx
     }
 
-    /// Queue a message to be sent on the given channel.
     pub fn send(&self, id: u16, msg: Message) -> Result<(), mpsc::SendError<Message>> {
         if let Some(ch) = self.channels.get(&id) {
             ch.sender.send(msg)
@@ -54,9 +45,6 @@ impl Mux {
         }
     }
 
-    /// Poll all registered channels for outgoing frames. The first available
-    /// message is converted into a [`Frame`] and returned. If no messages are
-    /// pending, idle channels may generate keepalive frames.
     pub fn poll(&mut self) -> Option<Frame> {
         let now = Instant::now();
 
@@ -83,8 +71,6 @@ impl Mux {
                     }
                 }
                 Err(TryRecvError::Disconnected) => {
-                    // If the sender has gone away, treat as idle and emit
-                    // keepalives until the channel is dropped.
                     if now.duration_since(ch.last_sent) >= self.keepalive {
                         ch.last_sent = now;
                         self.next = (idx + 1) % len;

--- a/crates/protocol/tests/exit_codes.rs
+++ b/crates/protocol/tests/exit_codes.rs
@@ -1,3 +1,4 @@
+// crates/protocol/tests/exit_codes.rs
 use protocol::ExitCode;
 use std::convert::TryFrom;
 

--- a/crates/protocol/tests/golden_frames.rs
+++ b/crates/protocol/tests/golden_frames.rs
@@ -1,3 +1,4 @@
+// crates/protocol/tests/golden_frames.rs
 use protocol::{Frame, Message, Msg, Tag};
 
 #[test]

--- a/crates/protocol/tests/protocol.rs
+++ b/crates/protocol/tests/protocol.rs
@@ -1,3 +1,4 @@
+// crates/protocol/tests/protocol.rs
 use protocol::{negotiate_version, Frame, Message, Msg, Tag};
 
 #[test]
@@ -11,7 +12,6 @@ fn frame_roundtrip() {
     let msg2 = Message::from_frame(decoded).unwrap();
     assert_eq!(msg2, msg);
 
-    // A 4-byte payload should not be misinterpreted as a version message
     let msg4 = Message::Data(b"1234".to_vec());
     let frame4 = msg4.to_frame(3);
     let mut buf4 = Vec::new();
@@ -46,7 +46,6 @@ fn version_negotiation() {
 
 #[test]
 fn captured_frames_roundtrip() {
-    // File list entry
     const FILE_LIST: [u8; 16] = [
         0, 0, 0, 4, 0, 0, 0, 8, b'f', b'i', b'l', b'e', b'.', b't', b'x', b't',
     ];
@@ -61,7 +60,6 @@ fn captured_frames_roundtrip() {
         .unwrap();
     assert_eq!(buf, FILE_LIST);
 
-    // Attributes
     const ATTRS: [u8; 16] = [
         0, 0, 0, 5, 0, 0, 0, 8, b'm', b'o', b'd', b'e', b'=', b'7', b'5', b'5',
     ];
@@ -76,7 +74,6 @@ fn captured_frames_roundtrip() {
         .unwrap();
     assert_eq!(buf, ATTRS);
 
-    // Error
     const ERR: [u8; 12] = [0, 0, 0, 6, 0, 0, 0, 4, b'o', b'o', b'p', b's'];
     let frame = Frame::decode(&ERR[..]).unwrap();
     assert_eq!(frame.header.msg, Msg::Error);
@@ -89,7 +86,6 @@ fn captured_frames_roundtrip() {
         .unwrap();
     assert_eq!(buf, ERR);
 
-    // Progress
     const PROG: [u8; 16] = [0, 0, 0, 7, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 0x30, 0x39];
     let frame = Frame::decode(&PROG[..]).unwrap();
     assert_eq!(frame.header.msg, Msg::Progress);

--- a/crates/protocol/tests/server.rs
+++ b/crates/protocol/tests/server.rs
@@ -1,3 +1,4 @@
+// crates/protocol/tests/server.rs
 use compress::{available_codecs, encode_codecs};
 use protocol::{Server, CAP_CODECS, LATEST_VERSION};
 use std::io::Cursor;

--- a/crates/transport/src/lib.rs
+++ b/crates/transport/src/lib.rs
@@ -1,46 +1,36 @@
+// crates/transport/src/lib.rs
 use std::io::{self, Read, Write};
 
+mod rate;
 pub mod ssh;
 pub mod tcp;
-mod rate;
 
+pub use rate::RateLimitedTransport;
 pub use ssh::SshStdioTransport;
 pub use tcp::TcpTransport;
-pub use rate::RateLimitedTransport;
 
-/// Address family preference for network connections.
 #[derive(Clone, Copy, Debug)]
 pub enum AddressFamily {
-    /// Use IPv4 addresses only.
     V4,
-    /// Use IPv6 addresses only.
     V6,
 }
 
-/// Trait representing a blocking transport.
 pub trait Transport {
-    /// Send data over the transport.
     fn send(&mut self, data: &[u8]) -> io::Result<()>;
 
-    /// Receive data from the transport into the provided buffer.
-    ///
-    /// Returns the number of bytes read.
     fn receive(&mut self, buf: &mut [u8]) -> io::Result<usize>;
 }
 
-/// Transport implementation over local pipes using blocking I/O.
 pub struct LocalPipeTransport<R, W> {
     reader: R,
     writer: W,
 }
 
 impl<R, W> LocalPipeTransport<R, W> {
-    /// Create a new transport from the given reader and writer.
     pub fn new(reader: R, writer: W) -> Self {
         Self { reader, writer }
     }
 
-    /// Consume the transport and return the underlying reader and writer.
     pub fn into_inner(self) -> (R, W) {
         (self.reader, self.writer)
     }
@@ -57,8 +47,6 @@ impl<R: Read, W: Write> Transport for LocalPipeTransport<R, W> {
     }
 }
 
-/// Marker trait for transports carried over SSH.
 pub trait SshTransport: Transport {}
 
-/// Marker trait for transports that connect to an rsync daemon.
 pub trait DaemonTransport: Transport {}

--- a/crates/transport/src/rate.rs
+++ b/crates/transport/src/rate.rs
@@ -1,9 +1,9 @@
+// crates/transport/src/rate.rs
 use std::io;
 use std::time::{Duration, Instant};
 
 use crate::Transport;
 
-/// Transport wrapper that throttles outgoing bandwidth.
 pub struct RateLimitedTransport<T> {
     inner: T,
     bwlimit: u64,
@@ -12,12 +12,15 @@ pub struct RateLimitedTransport<T> {
 }
 
 impl<T> RateLimitedTransport<T> {
-    /// Create a new rate limited transport.
     pub fn new(inner: T, bwlimit: u64) -> Self {
-        Self { inner, bwlimit, start: Instant::now(), sent: 0 }
+        Self {
+            inner,
+            bwlimit,
+            start: Instant::now(),
+            sent: 0,
+        }
     }
 
-    /// Consume the wrapper returning the inner transport.
     pub fn into_inner(self) -> T {
         self.inner
     }

--- a/crates/transport/src/ssh.rs
+++ b/crates/transport/src/ssh.rs
@@ -1,3 +1,4 @@
+// crates/transport/src/ssh.rs
 use std::ffi::OsStr;
 use std::io::{self, BufReader, Read};
 use std::path::{Path, PathBuf};
@@ -16,7 +17,6 @@ use crate::{AddressFamily, LocalPipeTransport, SshTransport, Transport};
 const SSH_IO_BUF_SIZE: usize = 32 * 1024;
 const SSH_STDERR_CAP: usize = 32 * 1024;
 
-/// Transport over the stdio of a spawned `ssh` process.
 pub struct SshStdioTransport {
     inner: Option<LocalPipeTransport<BufReader<ChildStdout>, ChildStdin>>,
     stderr: Arc<Mutex<CapturedStderr>>,
@@ -44,7 +44,6 @@ struct CapturedStderr {
 }
 
 impl SshStdioTransport {
-    /// Spawn an SSH-like command and return a transport over its stdio.
     pub fn spawn<I, S>(program: &str, args: I) -> io::Result<Self>
     where
         I: IntoIterator<Item = S>,
@@ -55,7 +54,6 @@ impl SshStdioTransport {
         Self::spawn_from_command(cmd)
     }
 
-    /// Spawn a real `ssh` process targeting an rsync server and capture stderr.
     pub fn spawn_server<I, S>(
         host: &str,
         server_args: I,
@@ -69,8 +67,6 @@ impl SshStdioTransport {
     {
         let mut cmd = Command::new("ssh");
 
-        // Determine the known hosts file. Use the provided path or default to
-        // the user's `~/.ssh/known_hosts` if available.
         let known_hosts_path = known_hosts.map(Path::to_path_buf).or_else(|| {
             std::env::var("HOME")
                 .ok()
@@ -101,7 +97,6 @@ impl SshStdioTransport {
         Self::spawn_from_command(cmd)
     }
 
-    /// Spawn from a fully configured command.
     pub fn spawn_from_command(mut cmd: Command) -> io::Result<Self> {
         cmd.stdin(Stdio::piped())
             .stdout(Stdio::piped())
@@ -365,8 +360,6 @@ impl SshStdioTransport {
         Ok((t, codecs))
     }
 
-    /// Return any data captured from stderr of the spawned process along with
-    /// a flag indicating if the data was truncated.
     pub fn stderr(&self) -> (Vec<u8>, bool) {
         if let Ok(buf) = self.stderr.lock() {
             (buf.data.clone(), buf.truncated)
@@ -375,10 +368,6 @@ impl SshStdioTransport {
         }
     }
 
-    /// Consume the transport returning the reader and writer.
-    ///
-    /// This detaches the child process and stderr thread; the caller is
-    /// responsible for reaping the process.
     pub fn into_inner(mut self) -> (BufReader<ChildStdout>, ChildStdin) {
         if let Some(handle) = self.handle.take() {
             std::mem::forget(handle);
@@ -425,7 +414,6 @@ impl SshTransport for SshStdioTransport {}
 
 impl Drop for SshStdioTransport {
     fn drop(&mut self) {
-        // Close stdin/stdout before waiting on the child process.
         self.inner.take();
         if let Some(handle) = self.handle.take() {
             drop(handle);

--- a/crates/transport/src/tcp.rs
+++ b/crates/transport/src/tcp.rs
@@ -1,16 +1,15 @@
+// crates/transport/src/tcp.rs
 use std::io::{self, Read, Write};
 use std::net::{IpAddr, Ipv4Addr, SocketAddr, TcpListener, TcpStream, ToSocketAddrs};
 use std::time::Duration;
 
 use crate::{AddressFamily, DaemonTransport, Transport};
 
-/// Transport over a TCP stream to an rsync daemon.
 pub struct TcpTransport {
     stream: TcpStream,
 }
 
 impl TcpTransport {
-    /// Connect to the given host and port and return a TCP transport.
     pub fn connect(
         host: &str,
         port: u16,
@@ -32,13 +31,6 @@ impl TcpTransport {
         Ok(Self { stream })
     }
 
-    /// Create a TCP listener bound to the given address and port.
-    ///
-    /// Returns the listener along with the actual port it was bound to.  When
-    /// `port` is set to 0 the operating system will select a free ephemeral
-    /// port which is reported in the returned tuple.  This mirrors the
-    /// behaviour of `rsyncd.conf` where specifying `port 0` asks the daemon to
-    /// bind to any available port.
     pub fn listen(addr: Option<IpAddr>, port: u16) -> io::Result<(TcpListener, u16)> {
         let addr = addr.unwrap_or(IpAddr::V4(Ipv4Addr::UNSPECIFIED));
         let listener = TcpListener::bind((addr, port))?;
@@ -46,14 +38,10 @@ impl TcpTransport {
         Ok((listener, port))
     }
 
-    /// Create a transport from an existing `TcpStream`.
     pub fn from_stream(stream: TcpStream) -> Self {
         Self { stream }
     }
 
-    /// Send an authentication token terminated by a newline. If `token` is
-    /// `None` an empty line is sent which typically causes the daemon to
-    /// reject the connection when authentication is required.
     pub fn authenticate(&mut self, token: Option<&str>) -> io::Result<()> {
         if let Some(tok) = token {
             self.stream.write_all(tok.as_bytes())?;
@@ -61,7 +49,6 @@ impl TcpTransport {
         self.stream.write_all(b"\n")
     }
 
-    /// Configure a read timeout on the underlying `TcpStream`.
     pub fn set_read_timeout(&self, dur: Option<Duration>) -> io::Result<()> {
         self.stream.set_read_timeout(dur)
     }

--- a/crates/transport/tests/bwlimit.rs
+++ b/crates/transport/tests/bwlimit.rs
@@ -1,3 +1,4 @@
+// crates/transport/tests/bwlimit.rs
 use std::io;
 use std::time::{Duration, Instant};
 
@@ -8,7 +9,7 @@ fn rate_limited_transport_caps_speed() {
     let reader = io::empty();
     let writer = Vec::new();
     let inner = LocalPipeTransport::new(reader, writer);
-    let mut t = RateLimitedTransport::new(inner, 1024); // 1 KiB/s
+    let mut t = RateLimitedTransport::new(inner, 1024);
     let data = vec![0u8; 1024];
     let start = Instant::now();
     t.send(&data).unwrap();

--- a/crates/transport/tests/local_pipe.rs
+++ b/crates/transport/tests/local_pipe.rs
@@ -1,3 +1,4 @@
+// crates/transport/tests/local_pipe.rs
 use std::io::Cursor;
 
 use transport::{LocalPipeTransport, Transport};

--- a/crates/transport/tests/ssh_backpressure.rs
+++ b/crates/transport/tests/ssh_backpressure.rs
@@ -1,3 +1,4 @@
+// crates/transport/tests/ssh_backpressure.rs
 use std::io::{Read, Write};
 use std::thread;
 use std::time::Duration;
@@ -6,27 +7,23 @@ use transport::ssh::SshStdioTransport;
 
 #[test]
 fn backpressure_blocks_until_read() {
-    // Use a local echo server implemented via `cat`.
     let transport = SshStdioTransport::spawn("sh", ["-c", "cat"]).expect("spawn");
     let (mut reader, mut writer) = transport.into_inner();
 
-    let data = vec![0x55u8; 200_000]; // larger than typical pipe capacity
+    let data = vec![0x55u8; 200_000];
     let handle = thread::spawn({
         let data = data.clone();
         move || {
-            // This will block until the reader consumes data.
             writer.write_all(&data).expect("write_all");
         }
     });
 
-    // Give the writer some time to fill the pipe.
     thread::sleep(Duration::from_millis(100));
     assert!(
         !handle.is_finished(),
         "write completed without backpressure"
     );
 
-    // Drain the echoed data to release the backpressure.
     let mut buf = vec![0u8; data.len()];
     let mut read = 0;
     while read < buf.len() {

--- a/crates/transport/tests/ssh_process_cleanup.rs
+++ b/crates/transport/tests/ssh_process_cleanup.rs
@@ -1,3 +1,4 @@
+// crates/transport/tests/ssh_process_cleanup.rs
 use std::fs;
 use std::io;
 use std::thread::sleep;
@@ -9,7 +10,6 @@ use transport::{ssh::SshStdioTransport, Transport};
 fn no_zombie_after_drop() {
     let mut t = SshStdioTransport::spawn("sh", ["-c", "echo $$; read line"]).expect("spawn");
 
-    // Read the PID line from the child process.
     let mut pid_bytes = Vec::new();
     loop {
         let mut buf = [0u8; 1];
@@ -27,12 +27,9 @@ fn no_zombie_after_drop() {
         .parse()
         .unwrap();
 
-    // Drop the transport which should wait on the child process.
     drop(t);
-    // Allow some time for the OS to reap the process.
     sleep(Duration::from_millis(100));
 
-    // The process should no longer exist.
     let status_path = format!("/proc/{pid}/status");
     let err = fs::read_to_string(status_path).unwrap_err();
     assert_eq!(err.kind(), io::ErrorKind::NotFound);

--- a/crates/transport/tests/ssh_stderr_cap.rs
+++ b/crates/transport/tests/ssh_stderr_cap.rs
@@ -1,3 +1,4 @@
+// crates/transport/tests/ssh_stderr_cap.rs
 use std::time::Duration;
 use transport::ssh::SshStdioTransport;
 
@@ -9,12 +10,9 @@ fn caps_stderr_output() {
     let mut transport =
         SshStdioTransport::spawn("sh", ["-c", "head -c 100000 /dev/zero >&2"]).expect("spawn");
 
-    // wait for process to exit by draining stdout
     let mut buf = [0u8; 1];
     let _ = transport.receive(&mut buf).unwrap();
 
-    // stderr is captured asynchronously; wait until the reader thread finishes
-    // writing to the buffer.
     let mut attempts = 0;
     loop {
         let (stderr, truncated) = transport.stderr();

--- a/crates/transport/tests/ssh_stdio.rs
+++ b/crates/transport/tests/ssh_stdio.rs
@@ -1,8 +1,8 @@
+// crates/transport/tests/ssh_stdio.rs
 use transport::{ssh::SshStdioTransport, Transport};
 
 #[test]
 fn send_receive_via_ssh_stdio() {
-    // Spawn a simple echo process instead of real SSH for testing.
     let mut transport = SshStdioTransport::spawn("sh", ["-c", "cat"]).expect("spawn");
 
     transport.send(b"ping").expect("send");

--- a/crates/transport/tests/ssh_unknown_host.rs
+++ b/crates/transport/tests/ssh_unknown_host.rs
@@ -1,3 +1,4 @@
+// crates/transport/tests/ssh_unknown_host.rs
 use std::process::{Command, Stdio};
 use std::thread;
 use std::time::Duration;
@@ -7,7 +8,6 @@ use transport::ssh::SshStdioTransport;
 
 #[test]
 fn refuses_unknown_host_key() {
-    // Start a local SSH server in the background if available.
     if Command::new("/usr/sbin/sshd")
         .arg("-h")
         .stdout(Stdio::null())
@@ -27,17 +27,14 @@ fn refuses_unknown_host_key() {
         .spawn()
         .expect("spawn sshd");
 
-    // Give the server a moment to start listening on port 22.
     thread::sleep(Duration::from_millis(500));
 
-    // Use an empty known_hosts file to ensure the host key is unknown.
     let tmp = NamedTempFile::new().expect("tmp known_hosts");
 
     let transport =
         SshStdioTransport::spawn_server("localhost", ["/"], Some(tmp.path()), true, None)
             .expect("spawn ssh");
 
-    // Give the ssh process time to emit its failure message.
     thread::sleep(Duration::from_millis(500));
 
     let (stderr, truncated) = transport.stderr();

--- a/crates/transport/tests/tcp.rs
+++ b/crates/transport/tests/tcp.rs
@@ -1,3 +1,4 @@
+// crates/transport/tests/tcp.rs
 use std::io::{Read, Write};
 use std::net::TcpListener;
 use std::thread;
@@ -6,7 +7,6 @@ use transport::{tcp::TcpTransport, Transport};
 
 #[test]
 fn send_receive_over_tcp() {
-    // Start a simple echo server.
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
     let addr = listener.local_addr().unwrap();
 
@@ -18,8 +18,7 @@ fn send_receive_over_tcp() {
     });
 
     let mut transport =
-        TcpTransport::connect(&addr.ip().to_string(), addr.port(), None, None)
-            .expect("connect");
+        TcpTransport::connect(&addr.ip().to_string(), addr.port(), None, None).expect("connect");
     transport.send(b"ping").expect("send");
     let mut buf = [0u8; 4];
     let n = transport.receive(&mut buf).expect("receive");

--- a/crates/walk/tests/walk.rs
+++ b/crates/walk/tests/walk.rs
@@ -1,3 +1,4 @@
+// crates/walk/tests/walk.rs
 use std::fs;
 use tempfile::tempdir;
 use walk::walk;

--- a/docs/crates/protocol/src/lib.md
+++ b/docs/crates/protocol/src/lib.md
@@ -1,0 +1,12 @@
+# crates/protocol/src/lib.rs
+
+Core frame and message types for the rsync protocol.
+
+
+Messages are exchanged in several phases including version negotiation,
+
+file-list transmission, attribute exchange, progress updates and error
+
+reporting. Each phase corresponds to a [`Message`] variant encoded inside
+
+multiplexed [`Frame`] structures.

--- a/docs/fuzz/src/lib.md
+++ b/docs/fuzz/src/lib.md
@@ -1,0 +1,13 @@
+# fuzz/src/lib.rs
+
+Shared helper utilities for fuzzing targets.
+
+
+Utilities that are reused across fuzz targets.
+
+
+Keeping the helpers in a separate module makes it easy for each
+
+fuzz target to pull in the small bits of functionality it needs
+
+without repeating boilerplate.

--- a/fuzz/fuzz_targets/daemon_auth_token_parser.rs
+++ b/fuzz/fuzz_targets/daemon_auth_token_parser.rs
@@ -1,3 +1,4 @@
+// fuzz/fuzz_targets/daemon_auth_token_parser.rs
 #![no_main]
 use cli::parse_auth_token;
 use libfuzzer_sys::fuzz_target;

--- a/fuzz/fuzz_targets/dirent_parser.rs
+++ b/fuzz/fuzz_targets/dirent_parser.rs
@@ -1,3 +1,4 @@
+// fuzz/fuzz_targets/dirent_parser.rs
 #![no_main]
 use libfuzzer_sys::fuzz_target;
 use std::fs;

--- a/fuzz/fuzz_targets/filter_parser.rs
+++ b/fuzz/fuzz_targets/filter_parser.rs
@@ -1,3 +1,4 @@
+// fuzz/fuzz_targets/filter_parser.rs
 #![no_main]
 use filters::parse;
 use fuzz::helpers;

--- a/fuzz/fuzz_targets/filters.rs
+++ b/fuzz/fuzz_targets/filters.rs
@@ -1,3 +1,4 @@
+// fuzz/fuzz_targets/filters.rs
 #![no_main]
 use filters::{parse, Matcher};
 use fuzz::helpers;

--- a/fuzz/fuzz_targets/filters_merge_fuzz.rs
+++ b/fuzz/fuzz_targets/filters_merge_fuzz.rs
@@ -1,3 +1,4 @@
+// fuzz/fuzz_targets/filters_merge_fuzz.rs
 #![no_main]
 use filters::{parse, Matcher};
 use std::collections::HashSet;

--- a/fuzz/fuzz_targets/filters_parse_fuzz.rs
+++ b/fuzz/fuzz_targets/filters_parse_fuzz.rs
@@ -1,3 +1,4 @@
+// fuzz/fuzz_targets/filters_parse_fuzz.rs
 #![no_main]
 use fuzz::helpers;
 use libfuzzer_sys::fuzz_target;

--- a/fuzz/fuzz_targets/protocol_frame_decode_fuzz.rs
+++ b/fuzz/fuzz_targets/protocol_frame_decode_fuzz.rs
@@ -1,3 +1,4 @@
+// fuzz/fuzz_targets/protocol_frame_decode_fuzz.rs
 #![no_main]
 use fuzz::helpers;
 use libfuzzer_sys::fuzz_target;

--- a/fuzz/src/lib.rs
+++ b/fuzz/src/lib.rs
@@ -1,27 +1,12 @@
-//! Shared helper utilities for fuzzing targets.
-
-/// Utilities that are reused across fuzz targets.
-///
-/// Keeping the helpers in a separate module makes it easy for each
-/// fuzz target to pull in the small bits of functionality it needs
-/// without repeating boilerplate.
+// fuzz/src/lib.rs
 pub mod helpers {
     use std::io::Cursor;
 
-    /// Wrap the provided byte slice in a [`Cursor`].
-    ///
-    /// Many fuzz targets operate on types that expect an `io::Read`
-    /// implementation.  A `Cursor` over the input bytes satisfies that
-    /// requirement without allocating.
     #[inline]
     pub fn cursor(data: &[u8]) -> Cursor<&[u8]> {
         Cursor::new(data)
     }
 
-    /// Attempt to interpret the provided byte slice as UTF‑8.
-    ///
-    /// Returning `None` instead of panicking keeps fuzz targets simple
-    /// when they need optional textual input.
     #[inline]
     pub fn as_str(data: &[u8]) -> Option<&str> {
         std::str::from_utf8(data).ok()

--- a/src/bin/rsync-rs.rs
+++ b/src/bin/rsync-rs.rs
@@ -1,1 +1,2 @@
+// src/bin/rsync-rs.rs
 include!("../../bin/rsync-rs/src/main.rs");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,9 @@
-use std::path::Path;
+// src/lib.rs
 use compress::available_codecs;
 use engine::{Result, SyncOptions};
 use filters::Matcher;
+use std::path::Path;
 
-/// Re-export engine synchronization for convenience.
 pub fn synchronize(src: &Path, dst: &Path) -> Result<()> {
     engine::sync(
         src,

--- a/tests/block_size.rs
+++ b/tests/block_size.rs
@@ -1,3 +1,4 @@
+// tests/block_size.rs
 use assert_cmd::Command;
 use checksums::ChecksumConfigBuilder;
 use engine::{compute_delta, Op};
@@ -30,7 +31,7 @@ fn delta_block_size_matches_rsync() {
         let src_file = src_dir.join("file.bin");
         let dst_file = dst_dir.join("file.bin");
 
-        let size = 1 << 20; // 1 MiB
+        let size = 1 << 20;
         let mut basis = vec![0u8; size];
         for i in 0..size {
             basis[i] = (i % 256) as u8;
@@ -41,7 +42,6 @@ fn delta_block_size_matches_rsync() {
         fs::write(&src_file, &target).unwrap();
         fs::write(&dst_file, &basis).unwrap();
 
-        // compute delta using engine
         let cfg = ChecksumConfigBuilder::new().build();
         let mut basis_f = fs::File::open(&dst_file).unwrap();
         let mut target_f = fs::File::open(&src_file).unwrap();
@@ -51,10 +51,12 @@ fn delta_block_size_matches_rsync() {
             .collect();
         let literal: usize = ops
             .iter()
-            .map(|op| match op { Op::Data(d) => d.len(), _ => 0 })
+            .map(|op| match op {
+                Op::Data(d) => d.len(),
+                _ => 0,
+            })
             .sum();
 
-        // run rsync and parse literal data
         let output = StdCommand::new("rsync")
             .arg("--stats")
             .arg("--recursive")
@@ -71,7 +73,6 @@ fn delta_block_size_matches_rsync() {
         assert_eq!(literal, rsync_literal);
         assert_eq!(literal, block_size);
 
-        // reset dst and ensure rsync-rs accepts the flag
         fs::write(&dst_file, &basis).unwrap();
         let src_arg = format!("{}/", src_dir.display());
         Command::cargo_bin("rsync-rs")
@@ -92,8 +93,8 @@ fn delta_block_size_matches_rsync() {
 
 #[test]
 fn delta_block_size_large_file() {
-    let block_size = 8192usize; // 8 KiB
-    let size = 8 * 1024 * 1024; // 8 MiB
+    let block_size = 8192usize;
+    let size = 8 * 1024 * 1024;
     let dir = tempdir().unwrap();
     let src_dir = dir.path().join("src");
     let dst_dir = dir.path().join("dst");
@@ -112,7 +113,6 @@ fn delta_block_size_large_file() {
     fs::write(&src_file, &target).unwrap();
     fs::write(&dst_file, &basis).unwrap();
 
-    // engine delta
     let cfg = ChecksumConfigBuilder::new().build();
     let mut basis_f = fs::File::open(&dst_file).unwrap();
     let mut target_f = fs::File::open(&src_file).unwrap();
@@ -122,7 +122,10 @@ fn delta_block_size_large_file() {
         .collect();
     let literal: usize = ops
         .iter()
-        .map(|op| match op { Op::Data(d) => d.len(), _ => 0 })
+        .map(|op| match op {
+            Op::Data(d) => d.len(),
+            _ => 0,
+        })
         .sum();
 
     let output = StdCommand::new("rsync")

--- a/tests/cvs_exclude.rs
+++ b/tests/cvs_exclude.rs
@@ -1,3 +1,4 @@
+// tests/cvs_exclude.rs
 use assert_cmd::Command;
 use std::fs;
 use std::process::Command as StdCommand;

--- a/tests/daemon.rs
+++ b/tests/daemon.rs
@@ -1,3 +1,4 @@
+// tests/daemon.rs
 use assert_cmd::prelude::*;
 use assert_cmd::Command;
 use protocol::LATEST_VERSION;
@@ -282,7 +283,6 @@ fn daemon_accepts_authorized_client() {
 #[test]
 #[serial]
 fn daemon_respects_host_allow_and_deny_lists() {
-    // Allow list
     let (mut child, port) = {
         let port = TcpListener::bind("127.0.0.1:0")
             .unwrap()
@@ -313,7 +313,6 @@ fn daemon_respects_host_allow_and_deny_lists() {
     let _ = child.kill();
     let _ = child.wait();
 
-    // Deny list
     let (mut child, port) = {
         let port = TcpListener::bind("127.0.0.1:0")
             .unwrap()

--- a/tests/daemon_sync_attrs.rs
+++ b/tests/daemon_sync_attrs.rs
@@ -1,3 +1,4 @@
+// tests/daemon_sync_attrs.rs
 #[cfg(all(unix, any(feature = "xattr", feature = "acl")))]
 use assert_cmd::{cargo::CommandCargoExt, Command};
 #[cfg(all(unix, any(feature = "xattr", feature = "acl")))]

--- a/tests/filter_corpus.rs
+++ b/tests/filter_corpus.rs
@@ -1,3 +1,4 @@
+// tests/filter_corpus.rs
 use assert_cmd::Command;
 use shell_words::split;
 use std::fs;

--- a/tests/interop/codec_negotiation.rs
+++ b/tests/interop/codec_negotiation.rs
@@ -1,3 +1,4 @@
+// tests/interop/codec_negotiation.rs
 use compress::{negotiate_codec, Codec};
 
 #[test]

--- a/tests/interop/daemon_tests.rs
+++ b/tests/interop/daemon_tests.rs
@@ -1,1 +1,2 @@
+// tests/interop/daemon_tests.rs
 include!("../daemon.rs");

--- a/tests/interop/filter_complex.rs
+++ b/tests/interop/filter_complex.rs
@@ -1,3 +1,4 @@
+// tests/interop/filter_complex.rs
 use assert_cmd::Command;
 use std::fs;
 use std::process::Command as StdCommand;

--- a/tests/interop/modern.rs
+++ b/tests/interop/modern.rs
@@ -1,1 +1,2 @@
+// tests/interop/modern.rs
 include!("../modern.rs");

--- a/tests/interop/remote_remote_tests.rs
+++ b/tests/interop/remote_remote_tests.rs
@@ -1,3 +1,2 @@
-// Reuse the core remote-remote tests in the interop test suite so CI exercises
-// them against real transports as well.
+// tests/interop/remote_remote_tests.rs
 include!(concat!(env!("CARGO_MANIFEST_DIR"), "/tests/remote_remote.rs"));

--- a/tests/link_copy_compare_dest.rs
+++ b/tests/link_copy_compare_dest.rs
@@ -1,3 +1,4 @@
+// tests/link_copy_compare_dest.rs
 use assert_cmd::Command;
 use std::collections::BTreeMap;
 use std::fs;

--- a/tests/local_sync_tree.rs
+++ b/tests/local_sync_tree.rs
@@ -1,10 +1,11 @@
+// tests/local_sync_tree.rs
 use assert_cmd::Command;
 use std::collections::BTreeMap;
 use std::fs;
-#[cfg(unix)]
-use std::os::unix::fs::{MetadataExt, PermissionsExt};
 #[cfg(target_os = "linux")]
 use std::os::unix::fs::FileTypeExt;
+#[cfg(unix)]
+use std::os::unix::fs::{MetadataExt, PermissionsExt};
 use std::path::{Path, PathBuf};
 use tempfile::tempdir;
 
@@ -50,7 +51,6 @@ fn sync_directory_tree() {
 #[cfg(all(unix, feature = "xattr"))]
 #[test]
 fn sync_preserves_xattrs() {
-    // Ensure extended attributes survive a local sync when the feature is enabled.
     let tmp = tempdir().unwrap();
     let src = tmp.path().join("src");
     let dst = tmp.path().join("dst");
@@ -77,8 +77,6 @@ fn sync_preserves_xattrs() {
 #[test]
 fn sync_preserves_acls() {
     use posix_acl::{PosixACL, Qualifier, ACL_READ};
-
-    // Ensure POSIX ACLs survive a local sync when the feature is enabled.
 
     let tmp = tempdir().unwrap();
     let src = tmp.path().join("src");
@@ -118,7 +116,12 @@ fn sync_preserves_owner_and_group() {
     fs::create_dir_all(&dst).unwrap();
     let file = src.join("file");
     fs::write(&file, b"hi").unwrap();
-    chown(&file, Some(Uid::from_raw(12345)), Some(Gid::from_raw(54321))).unwrap();
+    chown(
+        &file,
+        Some(Uid::from_raw(12345)),
+        Some(Gid::from_raw(54321)),
+    )
+    .unwrap();
 
     let src_arg = format!("{}/", src.display());
     Command::cargo_bin("rsync-rs")
@@ -189,12 +192,7 @@ fn sync_preserves_crtimes() {
     let src_arg = format!("{}/", src.display());
     Command::cargo_bin("rsync-rs")
         .unwrap()
-        .args([
-            "--local",
-            "--crtimes",
-            &src_arg,
-            dst.to_str().unwrap(),
-        ])
+        .args(["--local", "--crtimes", &src_arg, dst.to_str().unwrap()])
         .assert()
         .success()
         .stdout("")

--- a/tests/modern.rs
+++ b/tests/modern.rs
@@ -1,3 +1,4 @@
+// tests/modern.rs
 use checksums::{strong_digest, StrongHash};
 use compress::{available_codecs, Codec};
 use engine::{select_codec, SyncOptions};
@@ -30,4 +31,3 @@ fn modern_falls_back_without_compress() {
     );
     assert!(negotiated.is_none());
 }
-

--- a/tests/remote_utils.rs
+++ b/tests/remote_utils.rs
@@ -1,12 +1,11 @@
+// tests/remote_utils.rs
 #![cfg(unix)]
 use transport::ssh::SshStdioTransport;
 
-/// Spawn a "remote" reader using the local shell.
 pub fn spawn_reader(cmd: &str) -> SshStdioTransport {
     SshStdioTransport::spawn("sh", ["-c", cmd]).expect("spawn")
 }
 
-/// Spawn a "remote" writer using the local shell.
 pub fn spawn_writer(cmd: &str) -> SshStdioTransport {
     SshStdioTransport::spawn("sh", ["-c", cmd]).expect("spawn")
 }

--- a/tests/resume.rs
+++ b/tests/resume.rs
@@ -1,3 +1,4 @@
+// tests/resume.rs
 use assert_cmd::prelude::*;
 use std::process::Command;
 use std::thread;

--- a/tests/rsync_path.rs
+++ b/tests/rsync_path.rs
@@ -1,8 +1,9 @@
+// tests/rsync_path.rs
 use assert_cmd::Command;
 use std::fs;
-use tempfile::tempdir;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
+use tempfile::tempdir;
 
 #[cfg(unix)]
 #[test]
@@ -14,14 +15,12 @@ fn custom_rsync_path_performs_transfer() {
     fs::write(&src_file, b"from custom binary").unwrap();
     let dst_dir = dir.path().join("dst");
 
-    // Copy the client binary to act as the remote rsync executable.
     let remote_bin = dir.path().join("rr-remote");
     fs::copy(assert_cmd::cargo::cargo_bin("rsync-rs"), &remote_bin).unwrap();
     let mut perms = fs::metadata(&remote_bin).unwrap().permissions();
     perms.set_mode(0o755);
     fs::set_permissions(&remote_bin, perms).unwrap();
 
-    // Create a fake remote shell that ignores the host argument.
     let rsh = dir.path().join("fake_rsh.sh");
     fs::write(&rsh, b"#!/bin/sh\nshift\nexec \"$@\"\n").unwrap();
     fs::set_permissions(&rsh, fs::Permissions::from_mode(0o755)).unwrap();

--- a/tests/rsync_zlib.rs
+++ b/tests/rsync_zlib.rs
@@ -1,26 +1,22 @@
+// tests/rsync_zlib.rs
 use compress::Codec;
 use protocol::{negotiate_version, CAP_CODECS, LATEST_VERSION};
 use transport::{ssh::SshStdioTransport, Transport};
 
 #[test]
 fn rsync_client_falls_back_to_zlib() {
-    // Spawn a stock rsync server in --server mode and perform the handshake
-    // to ensure it doesn't advertise codec support.
     let mut t = SshStdioTransport::spawn("rsync", ["--server", "."]).unwrap();
 
-    // Exchange versions
     t.send(&LATEST_VERSION.to_be_bytes()).unwrap();
     let mut buf = [0u8; 4];
     t.receive(&mut buf).unwrap();
     negotiate_version(u32::from_be_bytes(buf)).unwrap();
 
-    // Send our capability bitmask and read the server's response
     t.send(&CAP_CODECS.to_be_bytes()).unwrap();
     t.receive(&mut buf).unwrap();
     let caps = u32::from_be_bytes(buf);
     assert_eq!(caps & CAP_CODECS, 0);
 
-    // Without the capability bit the negotiated codec defaults to zlib.
     let negotiated = vec![Codec::Zlib];
     assert_eq!(negotiated, vec![Codec::Zlib]);
 }

--- a/tests/symlink_resolution.rs
+++ b/tests/symlink_resolution.rs
@@ -1,3 +1,4 @@
+// tests/symlink_resolution.rs
 use assert_cmd::Command;
 use std::fs;
 use std::path::Path;

--- a/tests/timeout.rs
+++ b/tests/timeout.rs
@@ -1,3 +1,4 @@
+// tests/timeout.rs
 use std::io;
 use std::net::TcpListener;
 use std::thread;

--- a/tests/transport.rs
+++ b/tests/transport.rs
@@ -1,3 +1,4 @@
+// tests/transport.rs
 use std::io::Write;
 use std::net::TcpListener;
 use std::thread;

--- a/tools/flag_matrix.rs
+++ b/tools/flag_matrix.rs
@@ -1,3 +1,4 @@
+// tools/flag_matrix.rs
 use std::collections::{BTreeSet, HashMap};
 use std::fs;
 use std::process::Command;
@@ -74,10 +75,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let rsync_rs_help_str = String::from_utf8(rsync_rs_help.stdout)?;
     let (rsync_rs_flags, rsync_rs_aliases, _rsync_rs_alias_desc) = parse_help(&rsync_rs_help_str);
 
-    let error_notes: HashMap<&str, &str> = [
-    ]
-    .into_iter()
-    .collect();
+    let error_notes: HashMap<&str, &str> = [].into_iter().collect();
 
     let ignored_flags: BTreeSet<&str> = BTreeSet::new();
 

--- a/tools/gen_completions.rs
+++ b/tools/gen_completions.rs
@@ -1,3 +1,4 @@
+// tools/gen_completions.rs
 use std::env;
 use std::fs;
 


### PR DESCRIPTION
## Summary
- Add file-path header comments to every Rust source file
- Strip all inline and documentation comments
- Move top-level docs into `docs/`

## Testing
- `cargo fmt`
- `cargo test` *(hangs on `remote_remote_via_ssh_paths` after 60s)*

------
https://chatgpt.com/codex/tasks/task_e_68b2ef9710dc8323a439fd673e796aa1