### PR TITLE
Fix TCP listener address selection

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -7,7 +7,7 @@ use std::net::{IpAddr, TcpStream};
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 
-use daemon::{authenticate, chroot_and_drop_privileges, parse_module, Module};
+use daemon::chroot_and_drop_privileges;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
@@ -1470,7 +1470,14 @@ fn run_daemon(opts: DaemonOpts) -> Result<()> {
     let motd = opts.motd.clone();
     let timeout = opts.timeout;
     let bwlimit = opts.bwlimit;
-    let (listener, port) = TcpTransport::listen(opts.address, opts.port)?;
+    let family = if opts.ipv4 {
+        Some(AddressFamily::V4)
+    } else if opts.ipv6 {
+        Some(AddressFamily::V6)
+    } else {
+        None
+    };
+    let (listener, port) = TcpTransport::listen(opts.address, opts.port, family)?;
     if opts.port == 0 {
         println!("{}", port);
         let _ = io::stdout().flush();

--- a/crates/transport/src/tcp.rs
+++ b/crates/transport/src/tcp.rs
@@ -31,8 +31,12 @@ impl TcpTransport {
         Ok(Self { stream })
     }
 
-    pub fn listen(addr: Option<IpAddr>, port: u16) -> io::Result<(TcpListener, u16)> {
-        let addr = addr.unwrap_or(IpAddr::V4(Ipv4Add
+    pub fn listen(
+        addr: Option<IpAddr>,
+        port: u16,
+        family: Option<AddressFamily>,
+    ) -> io::Result<(TcpListener, u16)> {
+        let addr = match (addr, family) {
             (Some(ip), _) => ip,
             (None, Some(AddressFamily::V4)) => IpAddr::V4(Ipv4Addr::UNSPECIFIED),
             (None, Some(AddressFamily::V6)) => IpAddr::V6(Ipv6Addr::UNSPECIFIED),


### PR DESCRIPTION
## Summary
- allow choosing IPv4 or IPv6 when starting daemon listener
- plumb ipv4/ipv6 CLI flags into TcpTransport::listen

## Testing
- `cargo test` *(fails: remote_remote_via_ssh_paths has been running for over 60 seconds)*

------
https://chatgpt.com/codex/tasks/task_e_68b2f9c1c910832398698e8171efc7db