### PR TITLE
Add compression tests and raise coverage threshold

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
         run: cargo install cargo-llvm-cov --locked
       - name: Coverage
         if: matrix.os == 'ubuntu-latest' && matrix.use-cross == false
-        run: cargo llvm-cov --all-features --workspace --fail-under-lines 92 --fail-under-functions 92 --lcov --output-path lcov.info
+        run: cargo llvm-cov --all-features --workspace --fail-under-lines 95 --fail-under-functions 95 --lcov --output-path lcov.info
       - name: Upload coverage report
         if: matrix.os == 'ubuntu-latest' && matrix.use-cross == false
         uses: actions/upload-artifact@v4
@@ -228,7 +228,7 @@ jobs:
       - name: Install cargo-llvm-cov
         run: cargo install cargo-llvm-cov --locked
       - name: Generate coverage report
-        run: cargo llvm-cov --all-features --workspace --fail-under-lines 92 --fail-under-functions 92 --lcov --output-path lcov.info
+        run: cargo llvm-cov --all-features --workspace --fail-under-lines 95 --fail-under-functions 95 --lcov --output-path lcov.info
       - name: Upload coverage report
         uses: actions/upload-artifact@v4
         with:

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -270,7 +270,7 @@ struct ClientOpts {
         short = 'C',
         long = "cvs-exclude",
         help_heading = "Selection",
-        help = "auto-ignore files in the same way CVS does",
+        help = "auto-ignore files in the same way CVS does"
     )]
     cvs_exclude: bool,
     #[arg(long, value_name = "PATTERN")]
@@ -1818,6 +1818,12 @@ mod tests {
         assert_eq!(opts.rsync_path.as_deref(), Some("/bin/rsync"));
         let opts = ClientOpts::parse_from(["prog", "--rsync_path", "/bin/rsync", "src", "dst"]);
         assert_eq!(opts.rsync_path.as_deref(), Some("/bin/rsync"));
+    }
+
+    #[test]
+    fn parses_skip_compress_list() {
+        let opts = ClientOpts::parse_from(["prog", "--skip-compress=gz,zip", "src", "dst"]);
+        assert_eq!(opts.skip_compress, vec!["gz", "zip"]);
     }
 
     #[test]

--- a/crates/compress/tests/codecs.rs
+++ b/crates/compress/tests/codecs.rs
@@ -1,7 +1,12 @@
 // crates/compress/tests/codecs.rs
 #[cfg(feature = "lz4")]
 use compress::Lz4;
-use compress::{negotiate_codec, Codec, Compressor, Decompressor, Zlib, Zstd};
+use compress::{
+    decode_codecs, encode_codecs, negotiate_codec, should_compress, Codec, Compressor,
+    Decompressor, Zlib, Zstd,
+};
+use std::io;
+use std::path::Path;
 
 const DATA: &[u8] = b"The quick brown fox jumps over the lazy dog";
 
@@ -37,4 +42,30 @@ fn negotiation_helper_picks_common_codec() {
     assert_eq!(negotiate_codec(&local, &remote), Some(Codec::Lz4));
     let remote2 = [Codec::Zstd];
     assert_eq!(negotiate_codec(&[Codec::Lz4], &remote2), None);
+}
+
+#[test]
+fn codec_from_byte_rejects_unknown() {
+    let err = Codec::from_byte(99).unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+}
+
+#[test]
+fn encode_decode_roundtrip_and_error() {
+    let codecs = vec![Codec::Zlib, Codec::Zstd];
+    let encoded = encode_codecs(&codecs);
+    assert_eq!(encoded, vec![0, 1]);
+    let decoded = decode_codecs(&encoded).expect("decode");
+    assert_eq!(decoded, codecs);
+    let err = decode_codecs(&[42]).unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+}
+
+#[test]
+fn should_compress_skips_matching_extensions() {
+    assert!(should_compress(Path::new("file.txt"), &[]));
+    assert!(!should_compress(
+        Path::new("archive.gz"),
+        &["gz".to_string()]
+    ));
 }

--- a/tests/golden/cli_parity/chmod.sh
+++ b/tests/golden/cli_parity/chmod.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+RSYNC_RS="$ROOT/target/debug/rsync-rs"
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+mkdir -p "$TMP/src" "$TMP/rsync_dst" "$TMP/rsync_rs_dst"
+
+echo data > "$TMP/src/a.txt"
+
+rsync_output=$(rsync --quiet --recursive --perms --chmod=go-rwx "$TMP/src/" "$TMP/rsync_dst" 2>&1)
+rsync_status=$?
+
+rsync_rs_raw=$("$RSYNC_RS" --local --recursive --perms --chmod=go-rwx "$TMP/src/" "$TMP/rsync_rs_dst" 2>&1)
+rsync_rs_status=$?
+rsync_rs_output=$(echo "$rsync_rs_raw" | grep -v -e 'recursive mode enabled' || true)
+
+if [ "$rsync_status" -ne "$rsync_rs_status" ]; then
+  echo "Exit codes differ: rsync=$rsync_status rsync-rs=$rsync_rs_status" >&2
+  exit 1
+fi
+
+if [ "$rsync_output" != "$rsync_rs_output" ]; then
+  echo "Outputs differ" >&2
+  diff -u <(printf "%s" "$rsync_output") <(printf "%s" "$rsync_rs_output") >&2 || true
+  exit 1
+fi
+
+if ! diff -r "$TMP/rsync_dst" "$TMP/rsync_rs_dst" >/dev/null; then
+  echo "Directory trees differ" >&2
+  diff -r "$TMP/rsync_dst" "$TMP/rsync_rs_dst" >&2 || true
+  exit 1
+fi
+
+rsync_mode=$(/usr/bin/python3 -c 'import os,sys; print(oct(os.stat(sys.argv[1]).st_mode & 0o777))' "$TMP/rsync_dst/a.txt")
+rsync_rs_mode=$(/usr/bin/python3 -c 'import os,sys; print(oct(os.stat(sys.argv[1]).st_mode & 0o777))' "$TMP/rsync_rs_dst/a.txt")
+if [ "$rsync_mode" != "$rsync_rs_mode" ]; then
+  echo "File modes differ: rsync=$rsync_mode rsync-rs=$rsync_rs_mode" >&2
+  exit 1
+fi

--- a/tests/skip_compress.rs
+++ b/tests/skip_compress.rs
@@ -1,0 +1,29 @@
+// tests/skip_compress.rs
+use assert_cmd::Command;
+use std::fs;
+use tempfile::tempdir;
+
+#[test]
+fn skip_compress_option_transfers_files() {
+    let dir = tempdir().unwrap();
+    let src = dir.path().join("src");
+    let dst = dir.path().join("dst");
+    fs::create_dir_all(&src).unwrap();
+    fs::write(src.join("a.gz"), b"data").unwrap();
+
+    let src_arg = format!("{}/", src.display());
+    Command::cargo_bin("rsync-rs")
+        .unwrap()
+        .args([
+            "--local",
+            "--compress",
+            "--skip-compress=gz",
+            &src_arg,
+            dst.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    let out = fs::read(dst.join("a.gz")).unwrap();
+    assert_eq!(out, b"data");
+}


### PR DESCRIPTION
## Summary
- expand codec tests with error cases and extension skipping logic
- test CLI parsing and runtime behavior for `--skip-compress`
- add golden parity check for `--chmod` flag
- tighten coverage requirement to 95% lines/functions

## Testing
- `cargo fmt --all` *(fails: mismatched closing delimiter in crates/transport/src/tcp.rs)*
- `cargo test` *(fails: mismatched closing delimiter in crates/transport/src/tcp.rs)*
- `make test-golden` *(fails: rustc requires `-Z unstable-options` to enable `check-cfg`)*

------
https://chatgpt.com/codex/tasks/task_e_68b2fb8f26908323b0400063778ec699