### PR TITLE
Handle errors instead of unwrap in CLI and protocol

### DIFF
--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -283,7 +283,7 @@ impl Message {
         match self {
             Message::Version(v) => {
                 let mut payload = Vec::new();
-                payload.write_u32::<BigEndian>(v).unwrap();
+                payload.extend_from_slice(&v.to_be_bytes());
                 let header = FrameHeader {
                     channel,
                     tag: Tag::Message,
@@ -351,7 +351,7 @@ impl Message {
             }
             Message::Progress(v) => {
                 let mut payload = Vec::new();
-                payload.write_u64::<BigEndian>(v).unwrap();
+                payload.extend_from_slice(&v.to_be_bytes());
                 let header = FrameHeader {
                     channel,
                     tag: Tag::Message,


### PR DESCRIPTION
## Summary
- parse environment commands without unwrap, returning Result
- replace unchecked writes in protocol message framing with infallible methods
- cover invalid env assignments with new unit test

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b30191ad34832387fa2b27cd196fbc