### PR TITLE
Support additional filter rule modifiers

### DIFF
--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -1007,7 +1007,7 @@ fn delete_extraneous(
             let file_type = entry.file_type;
             if let Ok(rel) = path.strip_prefix(dst) {
                 let included = matcher
-                    .is_included(rel)
+                    .is_included_for_delete(rel)
                     .map_err(|e| EngineError::Other(format!("{:?}", e)))?;
                 let src_exists = src.join(rel).exists();
                 if (included && !src_exists) || (!included && opts.delete_excluded) {

--- a/crates/filters/tests/rule_modifiers.rs
+++ b/crates/filters/tests/rule_modifiers.rs
@@ -1,0 +1,39 @@
+// crates/filters/tests/rule_modifiers.rs
+use filters::{parse, Matcher};
+use std::collections::HashSet;
+use std::fs;
+use tempfile::tempdir;
+
+#[test]
+fn sender_show_overrides_exclude() {
+    let mut v = HashSet::new();
+    let rules = parse("S debug.log\n- *.log\n", &mut v, 0).unwrap();
+    let matcher = Matcher::new(rules);
+    assert!(matcher.is_included("debug.log").unwrap());
+    assert!(!matcher.is_included("info.log").unwrap());
+}
+
+#[test]
+fn perishable_ignored_on_delete() {
+    let mut v = HashSet::new();
+    let rules = parse("-p tmp\n", &mut v, 0).unwrap();
+    let matcher = Matcher::new(rules);
+    assert!(!matcher.is_included("tmp").unwrap());
+    assert!(matcher.is_included_for_delete("tmp").unwrap());
+}
+
+#[test]
+fn per_dir_merge_precedence() {
+    let tmp = tempdir().unwrap();
+    let root = tmp.path();
+    fs::write(root.join(".rsync-filter"), "- *.log\n").unwrap();
+    fs::create_dir_all(root.join("sub")).unwrap();
+    fs::write(root.join("sub/.rsync-filter"), "S *.log\n").unwrap();
+
+    let mut v = HashSet::new();
+    let rules = parse(": /.rsync-filter\n", &mut v, 0).unwrap();
+    let matcher = Matcher::new(rules).with_root(root);
+
+    assert!(!matcher.is_included("debug.log").unwrap());
+    assert!(matcher.is_included("sub/debug.log").unwrap());
+}


### PR DESCRIPTION
## Summary
- handle sender/receiver, perishable, and CVS modifiers in filter rules
- add deletion-aware matching through `is_included_for_delete`
- test rule precedence and per-directory merging with new modifiers

## Testing
- `cargo test -p filters`
- `cargo test` *(fails: test remote_remote_via_ssh_paths has been running for over 60 seconds)*

------
https://chatgpt.com/codex/tasks/task_e_68b2fe034b388323b0c5e4f820fae422