### PR TITLE
Add support for itemized change output

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -75,7 +75,12 @@ struct ClientOpts {
     quiet: bool,
     #[arg(long, help_heading = "Output")]
     no_motd: bool,
-    #[arg(short = 'i', long = "itemize-changes", help_heading = "Output")]
+    #[arg(
+        short = 'i',
+        long = "itemize-changes",
+        help_heading = "Output",
+        help = "output a change-summary for all updates"
+    )]
     itemize_changes: bool,
     #[arg(long, help_heading = "Delete")]
     delete: bool,

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -1183,6 +1183,7 @@ pub fn sync(
                         println!("cd+++++++++ {}/", rel.display());
                     }
                 } else if file_type.is_symlink() {
+                    let created = !dest_path.exists();
                     let target = fs::read_link(&path)?;
                     let target_path = if target.is_absolute() {
                         target.clone()
@@ -1235,6 +1236,12 @@ pub fn sync(
                                 std::os::windows::fs::symlink_dir(&target, &dest_path)?;
                             } else {
                                 std::os::windows::fs::symlink_file(&target, &dest_path)?;
+                            }
+                        }
+                        if created {
+                            stats.files_transferred += 1;
+                            if opts.itemize_changes {
+                                println!("cL+++++++++ {} -> {}", rel.display(), target.display());
                             }
                         }
                     }

--- a/tests/golden/cli_parity/itemize-changes.sh
+++ b/tests/golden/cli_parity/itemize-changes.sh
@@ -10,10 +10,11 @@ mkdir -p "$TMP/src/subdir" "$TMP/rsync_dst" "$TMP/rsync_rs_dst"
 
 echo data > "$TMP/src/a.txt"
 echo data > "$TMP/src/subdir/b.txt"
+ln -s a.txt "$TMP/src/link"
 
-rsync_output=$(rsync --recursive --itemize-changes "$TMP/src/" "$TMP/rsync_dst" 2>&1 | grep -v 'sending incremental file list')
+rsync_output=$(rsync --recursive --links --itemize-changes "$TMP/src/" "$TMP/rsync_dst" 2>&1 | grep -v 'sending incremental file list')
 
-rsync_rs_raw=$("$RSYNC_RS" --local --recursive --itemize-changes "$TMP/src/" "$TMP/rsync_rs_dst" 2>&1)
+rsync_rs_raw=$("$RSYNC_RS" --local --recursive --links --itemize-changes "$TMP/src/" "$TMP/rsync_rs_dst" 2>&1)
 rsync_rs_output=$(echo "$rsync_rs_raw" | grep -v -e 'recursive mode enabled' || true)
 
 if [ "$rsync_output" != "$rsync_rs_output" ]; then


### PR DESCRIPTION
## Summary
- allow CLI parsing of `--itemize-changes` (`-i`) with help text
- emit rsync-style itemized output for newly created symlinks
- verify itemized change output, including symlink handling, against rsync

## Testing
- `bash tests/golden/cli_parity/itemize-changes.sh`
- `cargo test` *(one integration test noted runtime over 60s but suite continued)*

------
https://chatgpt.com/codex/tasks/task_e_68b310f3f4f88323aa98ffde3033f4fe