### PR TITLE
Add explicit human-readable flag and scale engine output

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -13,6 +13,7 @@ use std::time::Duration;
 
 use clap::{ArgAction, ArgMatches, CommandFactory, FromArgMatches, Parser};
 use compress::{available_codecs, Codec};
+use engine::human_bytes;
 use engine::{sync, DeleteMode, EngineError, Result, Stats, StrongHash, SyncOptions};
 use filters::{default_cvs_rules, parse, Matcher, Rule};
 use meta::{Chmod, ChmodOp, ChmodTarget};
@@ -29,26 +30,8 @@ fn parse_duration(s: &str) -> std::result::Result<Duration, std::num::ParseIntEr
     Ok(Duration::from_secs(s.parse()?))
 }
 
-fn human_bytes(bytes: u64) -> String {
-    const UNITS: [&str; 9] = ["B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB", "ZiB", "YiB"];
-    let mut size = bytes as f64;
-    let mut unit = 0;
-    while size >= 1024.0 && unit < UNITS.len() - 1 {
-        size /= 1024.0;
-        unit += 1;
-    }
-    if unit == 0 {
-        format!("{}{}", bytes, UNITS[unit])
-    } else {
-        format!("{:.2}{}", size, UNITS[unit])
-    }
-}
-
 #[derive(Parser, Debug)]
-#[command(disable_help_flag = true)]
 struct ClientOpts {
-    #[arg(long = "help", action = ArgAction::Help)]
-    _help: Option<bool>,
     #[arg(long)]
     local: bool,
     #[arg(short = 'a', long, help_heading = "Selection")]
@@ -69,7 +52,7 @@ struct ClientOpts {
     update: bool,
     #[arg(short, long, action = ArgAction::Count, help_heading = "Output")]
     verbose: u8,
-    #[arg(short = 'h', long = "human-readable", help_heading = "Output")]
+    #[arg(long = "human-readable", help_heading = "Output")]
     human_readable: bool,
     #[arg(short, long, help_heading = "Output")]
     quiet: bool,
@@ -970,6 +953,7 @@ fn run_client(opts: ClientOpts, matches: &ArgMatches) -> Result<()> {
         skip_compress: opts.skip_compress.clone(),
         partial: opts.partial || opts.partial_progress,
         progress: opts.progress || opts.partial_progress,
+        human_readable: opts.human_readable,
         itemize_changes: opts.itemize_changes,
         partial_dir: opts.partial_dir.clone(),
         temp_dir: opts.temp_dir.clone(),

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -130,7 +130,7 @@ The table below mirrors the full `rsync(1)` flag set. Defaults show the behavior
 |  | `--groupmap` | off |  | [matrix](feature_matrix.md#--groupmap) |
 | `-H` | `--hard-links` | off |  | [matrix](feature_matrix.md#--hard-links) |
 | `-h (*)` | `--help` | off |  | [matrix](feature_matrix.md#--help) |
-| `-h` | `--human-readable` | off |  | [matrix](feature_matrix.md#--human-readable) |
+|  | `--human-readable` | off |  | [matrix](feature_matrix.md#--human-readable) |
 |  | `--iconv` | off |  | [matrix](feature_matrix.md#--iconv) |
 |  | `--ignore-errors` | off |  | [matrix](feature_matrix.md#--ignore-errors) |
 |  | `--ignore-existing` | off |  | [matrix](feature_matrix.md#--ignore-existing) |

--- a/docs/cli/flags.md
+++ b/docs/cli/flags.md
@@ -125,7 +125,7 @@
 |  | --debug=FLAGS | fine-grained debug verbosity | no |  | no |
 | -h (*) | --help | show this help (* -h is help only on its own) Rsync can also be run as a daemon, in which case the following options are accepted: | no |  | no |
 | -h | --help | show this help (when used with --daemon) | no |  | no |
-| -h | --human-readable | output numbers in a human-readable format | no |  | no |
+|  | --human-readable | output numbers in a human-readable format | no |  | no |
 |  | --info=FLAGS | fine-grained informational verbosity | no |  | no |
 | -i | --itemize-changes | output a change-summary for all updates | no |  | no |
 |  | --list-only | list the files instead of copying them | no |  | no |

--- a/docs/feature_matrix.md
+++ b/docs/feature_matrix.md
@@ -68,7 +68,7 @@ See [differences.md](differences.md) for a summary of notable behavioral differe
 | `--groupmap` | — | ❌ | — | — |  | ≤3.2 |
 | `--hard-links` | `-H` | ✅ | ❌ | [tests/local_sync_tree.rs](../tests/local_sync_tree.rs) |  | ≤3.2 |
 | `--help` | `-h (*)` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  | ≤3.2 |
-| `--human-readable` | `-h` | ❌ | — | — |  | ≤3.2 |
+| `--human-readable` |  | ✅ | ✅ | [tests/golden/cli_parity/human-readable.sh](../tests/golden/cli_parity/human-readable.sh) |  | ≤3.2 |
 | `--iconv` | — | ❌ | — | — |  | ≤3.2 |
 | `--ignore-errors` | — | ❌ | — | — |  | ≤3.2 |
 | `--ignore-existing` | — | ❌ | — | — |  | ≤3.2 |

--- a/tools/flag_matrix.json
+++ b/tools/flag_matrix.json
@@ -296,7 +296,7 @@
   },
   {
     "flag": "--human-readable",
-    "status": "Error",
+    "status": "Supported",
     "notes": ""
   },
   {

--- a/tools/flag_matrix.md
+++ b/tools/flag_matrix.md
@@ -59,7 +59,7 @@
 | --groupmap | Error |  |
 | --hard-links | Supported |  |
 | --help | Supported |  |
-| --human-readable | Error |  |
+| --human-readable | Supported |  |
 | --iconv | Error |  |
 | --ignore-errors | Error |  |
 | --ignore-existing | Error |  |


### PR DESCRIPTION
## Summary
- add long `--human-readable` flag separate from `-h/--help`
- scale progress and stats output in engine with byte units
- document flag and cover with CLI parity test

## Testing
- `cargo test --workspace` *(fails: server_negotiates_version)*
- `cargo test -p cli -p engine`
- `make test-golden`


------
https://chatgpt.com/codex/tasks/task_e_68b319b004148323bd4180edc2bb499f