### PR TITLE
seed all strong checksums

### DIFF
--- a/crates/checksums/src/lib.rs
+++ b/crates/checksums/src/lib.rs
@@ -79,26 +79,20 @@ pub fn strong_digest(data: &[u8], alg: StrongHash, seed: u32) -> Vec<u8> {
     match alg {
         StrongHash::Md5 => {
             let mut hasher = Md5::new();
-            if seed != 0 {
-                hasher.update(&seed.to_le_bytes());
-            }
+            hasher.update(&seed.to_le_bytes());
             hasher.update(data);
             hasher.finalize().to_vec()
         }
         StrongHash::Sha1 => {
             let mut hasher = Sha1::new();
-            if seed != 0 {
-                hasher.update(&seed.to_le_bytes());
-            }
+            hasher.update(&seed.to_le_bytes());
             hasher.update(data);
             hasher.finalize().to_vec()
         }
         #[cfg(feature = "blake3")]
         StrongHash::Blake3 => {
             let mut hasher = Blake3::new();
-            if seed != 0 {
-                hasher.update(&seed.to_le_bytes());
-            }
+            hasher.update(&seed.to_le_bytes());
             hasher.update(data);
             hasher.finalize().as_bytes().to_vec()
         }


### PR DESCRIPTION
## Summary
- ensure Md5, Sha1, and Blake3 always hash the seed prefix
- strong checksum changes even when seed is zero

## Testing
- `cargo test --test checksum_seed`


------
https://chatgpt.com/codex/tasks/task_e_68b347d646008323a142fb1f0584f20e