### PR TITLE
Make log_format immutable in CLI daemon setup

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -1432,7 +1432,7 @@ fn run_daemon(opts: DaemonOpts) -> Result<()> {
     let mut hosts_allow = opts.hosts_allow.clone();
     let mut hosts_deny = opts.hosts_deny.clone();
     let mut log_file = opts.log_file.clone();
-    let mut log_format = opts.log_file_format.clone();
+    let log_format = opts.log_file_format.clone();
     let mut motd = opts.motd.clone();
     let timeout = opts.timeout;
     let bwlimit = opts.bwlimit;


### PR DESCRIPTION
## Summary
- remove unnecessary mutability from `log_format`

## Testing
- `cargo test -p cli`

------
https://chatgpt.com/codex/tasks/task_e_68b347e3540c8323a0333e3d78947d27