### PR TITLE
test: check cvs exclude removes cvsignore

### DIFF
--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -959,4 +959,5 @@ fn cvs_exclude_skips_ignored_files() {
     assert!(!dst.join("env_ignored").exists());
     assert!(!dst.join("home_ignored").exists());
     assert!(!dst.join("local_ignored").exists());
+    assert!(!dst.join(".cvsignore").exists());
 }


### PR DESCRIPTION
## Summary
- ensure `--cvs-exclude` prevents copying `.cvsignore`

## Testing
- `cargo test tests/cli.rs::cvs_exclude_skips_ignored_files`
- `cargo test --test cli cvs_exclude_skips_ignored_files` *(fails: assertion failed: !dst.join(".cvsignore").exists())*

------
https://chatgpt.com/codex/tasks/task_e_68b34ab282a883239e673e963507e4f6