### PR TITLE
Exclude cvsignore files when using --cvs-exclude

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -1411,7 +1411,10 @@ fn build_matcher(opts: &ClientOpts, matches: &ArgMatches) -> Result<Matcher> {
     }
     if opts.cvs_exclude {
         let mut cvs = default_cvs_rules().map_err(|e| EngineError::Other(format!("{:?}", e)))?;
-        cvs.extend(parse_filters(":C").map_err(|e| EngineError::Other(format!("{:?}", e)))?);
+        cvs.extend(
+            parse_filters(":C\n- .cvsignore\n- /.cvsignore")
+                .map_err(|e| EngineError::Other(format!("{:?}", e)))?,
+        );
         add_rules(usize::MAX, cvs);
     }
 


### PR DESCRIPTION
## Summary
- ensure `--cvs-exclude` filters out `.cvsignore` files explicitly

## Testing
- `cargo test tests/cvs_exclude.rs -- --nocapture`
- `cargo test --test cvs_exclude -- --nocapture` *(fails: directory trees differ)*

------
https://chatgpt.com/codex/tasks/task_e_68b34aa8fae88323bb2e195c61a759bc