### PR TITLE
Fix CVS ignore scoping and extend coverage

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -1411,10 +1411,7 @@ fn build_matcher(opts: &ClientOpts, matches: &ArgMatches) -> Result<Matcher> {
     }
     if opts.cvs_exclude {
         let mut cvs = default_cvs_rules().map_err(|e| EngineError::Other(format!("{:?}", e)))?;
-        cvs.extend(
-            parse_filters(":C\n- .cvsignore\n- /.cvsignore")
-                .map_err(|e| EngineError::Other(format!("{:?}", e)))?,
-        );
+        cvs.extend(parse_filters(":C\n").map_err(|e| EngineError::Other(format!("{:?}", e)))?);
         add_rules(usize::MAX, cvs);
     }
 

--- a/crates/filters/src/lib.rs
+++ b/crates/filters/src/lib.rs
@@ -331,8 +331,10 @@ impl Matcher {
                     } else {
                         format!("{}/{}", rel_str, token)
                     }
-                } else {
+                } else if token.starts_with('/') {
                     token.to_string()
+                } else {
+                    format!("/{}", token)
                 };
                 buf.push_str("- ");
                 buf.push_str(&pat);

--- a/crates/filters/tests/cvs_rules.rs
+++ b/crates/filters/tests/cvs_rules.rs
@@ -1,6 +1,9 @@
 // crates/filters/tests/cvs_rules.rs
 use filters::{parse, Matcher};
 use std::collections::HashSet;
+use std::env;
+use std::fs;
+use tempfile::tempdir;
 
 fn p(s: &str) -> Vec<filters::Rule> {
     let mut v = HashSet::new();
@@ -13,4 +16,42 @@ fn cvs_excludes_can_be_overridden() {
     let matcher = Matcher::new(rules);
     assert!(matcher.is_included("core").unwrap());
     assert!(!matcher.is_included("foo.o").unwrap());
+}
+
+#[test]
+fn cvsignore_is_scoped_per_directory() {
+    let tmp = tempdir().unwrap();
+    let root = tmp.path();
+    fs::write(root.join(".cvsignore"), "foo\n").unwrap();
+    let sub = root.join("sub");
+    fs::create_dir_all(&sub).unwrap();
+    fs::write(sub.join(".cvsignore"), "bar\n").unwrap();
+
+    let rules = p(":C\n");
+    let matcher = Matcher::new(rules).with_root(root);
+
+    assert!(!matcher.is_included("foo").unwrap());
+    assert!(matcher.is_included("sub/foo").unwrap());
+    assert!(matcher.is_included("bar").unwrap());
+    assert!(!matcher.is_included("sub/bar").unwrap());
+    assert!(matcher.is_included("sub/nested/bar").unwrap());
+}
+
+#[test]
+fn home_and_env_patterns_are_global() {
+    let home = tempdir().unwrap();
+    fs::write(home.path().join(".cvsignore"), "home_ignored\n").unwrap();
+    env::set_var("HOME", home.path());
+    env::set_var("CVSIGNORE", "env_ignored");
+
+    let rules = p("-C\n");
+    let matcher = Matcher::new(rules);
+
+    assert!(!matcher.is_included("home_ignored").unwrap());
+    assert!(!matcher.is_included("sub/home_ignored").unwrap());
+    assert!(!matcher.is_included("env_ignored").unwrap());
+    assert!(!matcher.is_included("sub/env_ignored").unwrap());
+
+    env::remove_var("HOME");
+    env::remove_var("CVSIGNORE");
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -959,5 +959,5 @@ fn cvs_exclude_skips_ignored_files() {
     assert!(!dst.join("env_ignored").exists());
     assert!(!dst.join("home_ignored").exists());
     assert!(!dst.join("local_ignored").exists());
-    assert!(!dst.join(".cvsignore").exists());
+    assert!(dst.join(".cvsignore").exists());
 }

--- a/tests/cvs_exclude.rs
+++ b/tests/cvs_exclude.rs
@@ -19,6 +19,18 @@ fn cvs_exclude_parity() {
     fs::write(src.join("local_ignored"), "local").unwrap();
     fs::write(src.join(".cvsignore"), "local_ignored\n").unwrap();
 
+    let sub = src.join("sub");
+    fs::create_dir_all(&sub).unwrap();
+    fs::write(sub.join("local_ignored"), "sublocal").unwrap();
+    fs::write(sub.join("env_ignored"), "env").unwrap();
+    fs::write(sub.join("home_ignored"), "home").unwrap();
+    fs::write(sub.join("sub_ignored"), "sub").unwrap();
+    fs::write(sub.join(".cvsignore"), "sub_ignored\n").unwrap();
+
+    let nested = sub.join("nested");
+    fs::create_dir_all(&nested).unwrap();
+    fs::write(nested.join("sub_ignored"), "nested").unwrap();
+
     let home = tempdir().unwrap();
     fs::write(home.path().join(".cvsignore"), "home_ignored\n").unwrap();
 


### PR DESCRIPTION
## Summary
- Anchor `.cvsignore` patterns to their directory so rules don’t leak into subdirs
- Stop `--cvs-exclude` from dropping `.cvsignore` files from transfers
- Add tests for per-dir `.cvsignore`, HOME/`$CVSIGNORE` patterns, and CLI parity

## Testing
- `cargo test -p filters`
- `cargo test --test cli`
- `cargo test --test cvs_exclude`


------
https://chatgpt.com/codex/tasks/task_e_68b34e4d3fec8323a04d3ec380d887e5