### PR TITLE
Handle implicit and nested .rsync-filter semantics

### DIFF
--- a/tests/filter_corpus.rs
+++ b/tests/filter_corpus.rs
@@ -21,14 +21,19 @@ fn setup_basic(src: &Path) {
 }
 
 fn setup_perdir(src: &Path) {
-    fs::create_dir_all(src.join("sub")).unwrap();
+    fs::create_dir_all(src.join("sub/nested")).unwrap();
     fs::write(src.join(".rsync-filter"), "- *.tmp\n").unwrap();
-    fs::write(src.join("sub/.rsync-filter"), "+ keep.tmp\n- *\n").unwrap();
+    fs::write(
+        src.join("sub/.rsync-filter"),
+        "+ nested/\n+ keep.tmp\n- *\n",
+    )
+    .unwrap();
     fs::write(src.join("sub/keep.tmp"), "keep").unwrap();
     fs::write(src.join("sub/other.tmp"), "other").unwrap();
     fs::write(src.join("sub/other.txt"), "other").unwrap();
-    fs::create_dir_all(src.join("sub/nested")).unwrap();
+    fs::write(src.join("sub/nested/.rsync-filter"), "+ keep.tmp\n- *\n").unwrap();
     fs::write(src.join("sub/nested/keep.tmp"), "nested").unwrap();
+    fs::write(src.join("sub/nested/other.tmp"), "other").unwrap();
 }
 
 fn setup_edge(src: &Path) {


### PR DESCRIPTION
## Summary
- Expand `-F` as `dir-merge .rsync-filter` and repeat as `- .rsync-filter`
- Scope nested per-directory merge files correctly and avoid loading excluded directories
- Cover `-F` and `-FF` per-directory behaviors in corpus tests

## Testing
- `cargo test --test filter_corpus`


------
https://chatgpt.com/codex/tasks/task_e_68b358ad533c83238070790b31a0219e